### PR TITLE
Remove HTTP timeouts from MoccaClient#Builder, support jaxrs.Client (not ClientBuilder) #7

### DIFF
--- a/docs/END_USER_DOCUMENT.md
+++ b/docs/END_USER_DOCUMENT.md
@@ -447,7 +447,7 @@ The method to create the builder also takes the server base URL as parameter. Th
 
 The actual client instance is then created by calling the `build` method, which takes as parameter the client API interface, whose definition was already explained earlier in this document.
 
-### 6.3 Choosing the HTTP client
+### 6.2 Choosing the HTTP client
 
 Mocca uses behind the scenes an HTTP client to make the GraphQL calls. By default, JDK `java.net.HttpURLConnection` is used as HTTP client, and no additional dependency is required to use it.
 
@@ -489,7 +489,7 @@ BooksAppClient client = MoccaClient.Builder
     .build(BooksAppClient.class);
 ```
 
-### 6.4 Setting HTTP headers
+### 6.3 Setting HTTP headers
 
 HTTP headers can be set in Mocca at client API or method level using `com.paypal.mocca.client.annotation.RequestHeader` annotation. When `@RequestHeader` annotation is added at client API level, the header will be included across all requests made through that client. The example below shows a header added at client API level.
 
@@ -540,7 +540,7 @@ A few important notes:
 1. If the same header is set at client API and method level, the one set at the method takes precedence
 1. If the same header is defined at the same method multiple times, all specified values will be set at the header value using comma as separator
 
-### 6.5 Gathering metrics
+### 6.4 Gathering metrics
 
 Mocca supports [Micrometer](https://micrometer.io/)-based metrics via the optional library `com.paypal.mocca:mocca-micrometer:0.0.2`. These metrics primarily revolve around HTTP interactions with the target GraphQL server. The metrics have identifiers that start with `mocca.`.
 
@@ -560,7 +560,7 @@ BooksAppClient micrometerEnabledClient = MoccaClient.Builder
     .build(BooksAppClient.class);
 ```
 
-### 6.6 Configuring resilience
+### 6.5 Configuring resilience
 
 Mocca supports [Resilience4j](https://github.com/resilience4j/resilience4j)-based resilience features via the optional library `com.paypal.mocca:mocca-resilience4j:0.0.2`.
 
@@ -594,7 +594,7 @@ A few important notes:
    1. Bulkhead
 1. The order of registering each resilience feature in `MoccaResilience4j` matters. More details at the next subsection.
 
-#### 6.6.1 Resilience features execution order
+#### 6.5.1 Resilience features execution order
 
 It is very important to state that the order in which resilience features are registered dictates the execution order.
 

--- a/docs/END_USER_DOCUMENT.md
+++ b/docs/END_USER_DOCUMENT.md
@@ -112,7 +112,7 @@ Book book = client.getBook(123);
 
 ### 2.4 Exploring other Mocca features
 
-For more information about how to use Mocca, and features like setting timeouts, using specific HTTP clients, asynchronous programming, and others, please read the other sections in this document.
+For more information about how to use Mocca, using specific HTTP clients, asynchronous programming, and others, please read the other sections in this document.
 
 ## 3 Client dependencies
 
@@ -447,20 +447,6 @@ The method to create the builder also takes the server base URL as parameter. Th
 
 The actual client instance is then created by calling the `build` method, which takes as parameter the client API interface, whose definition was already explained earlier in this document.
 
-### 6.2 Setting connection and read timeouts
-
-Optionally, connection and read timeouts can be customized, as shown in the example below:
-
-``` java
-BooksAppClient client = MoccaClient.Builder
-    .sync("http://localhost:8080/booksapp")
-    .connectionTimeout(1000)
-    .readTimeout(1000)
-    .build(BooksAppClient.class);
-```
-
-Both parameters are defined in milliseconds and, if not set explicitly, the default values are 10 seconds for connection timeout and 60 seconds for read timeout. Also, if prefered, they can be set using `java.time.Duration` instead of `long`.
-
 ### 6.3 Choosing the HTTP client
 
 Mocca uses behind the scenes an HTTP client to make the GraphQL calls. By default, JDK `java.net.HttpURLConnection` is used as HTTP client, and no additional dependency is required to use it.
@@ -470,8 +456,6 @@ However, if preferred, a custom HTTP client can be specified by adding an extra 
 ``` java
 BooksAppClient client = MoccaClient.Builder
     .sync("http://localhost:8080/booksapp")
-    .connectionTimeout(1000)
-    .readTimeout(1000)
     .client(new MoccaOkHttpClient())
     .build(BooksAppClient.class);
 ```
@@ -494,8 +478,6 @@ All Mocca classes mentioned in the table above work as a wrapper containing a de
 1. Mocca client builder could be used to do so, providing a common API regardless of the type of HTTP client used.
 1. A custom instance of the HTTP client could be provided as a constructor parameter to the Mocca HTTP client wrapper.
 
-Just for illustration purposes, in the example below read timeout is configured by setting it directly at the HTTP client, while connection timeout is set using Mocca builder API.
-
 ``` java
 okhttp3.OkHttpClient okHttpClient = new OkHttpClient().newBuilder()
     .readTimeout(2, TimeUnit.SECONDS)
@@ -503,7 +485,6 @@ okhttp3.OkHttpClient okHttpClient = new OkHttpClient().newBuilder()
 
 BooksAppClient client = MoccaClient.Builder
     .sync("localhost:8080/booksapp")
-    .connectionTimeout(2000)
     .client(new MoccaOkHttpClient(okHttpClient))
     .build(BooksAppClient.class);
 ```
@@ -706,8 +687,6 @@ MoccaAsyncApache5Client asyncHttpClient = new MoccaAsyncApache5Client(apacheAsyn
 
 BooksAppClient asyncClient = MoccaClient.Builder
     .async("http://localhost:8080/booksapp")
-    .connectionTimeout(1000)
-    .readTimeout(1000)
     .client(asyncHttpClient)
     .build(AsyncBooksAppClient.class);
 ```
@@ -741,7 +720,6 @@ MoccaExecutorHttpClient<OkHttpClient> executorClient = new MoccaExecutorHttpClie
 
 AsyncBooksAppClient asyncClient = MoccaClient.Builder
         .async("localhost:8080/booksapp")
-        .connectionTimeout(1000)
         .client(executorClient)
         .build(AsyncBooksAppClient.class);
 ```

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaClient.java
@@ -37,6 +37,10 @@ import java.util.Set;
  *     <li>The method name should be the same as the GraphQL operation name. If a different name is desired for the Java method, then the GraphQL operation name must be set using the {@code name} attribute in {@link com.paypal.mocca.client.annotation.Query} or {@link com.paypal.mocca.client.annotation.Mutation}.</li>
  * </ol>
  * <br>
+ * Ultimately, Mocca will make HTTP requests to a GraphQL service.  You can control things like HTTP timeouts by
+ * leveraging the functionality of the {@link MoccaHttpClient} implementations, which ultimately you can supply via
+ * {@link MoccaClient.Builder}.
+ * <br>
  * You can see below an example of a simple client API.
  * <pre><code>
  * import com.paypal.mocca.client.MoccaClient;

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaClient.java
@@ -3,17 +3,13 @@ package com.paypal.mocca.client;
 import feign.AsyncClient;
 import feign.AsyncFeign;
 import feign.Feign;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Applications are supposed to create an interface,
- * extending this one, to define their GraphQL client API.
- * Each GraphQL operation can be defined using Mocca
- * annotations under {@link com.paypal.mocca.client.annotation}.
+ * Applications are supposed to create an interface, extending this one, to define their GraphQL client API. Each
+ * GraphQL operation can be defined using Mocca annotations under {@link com.paypal.mocca.client.annotation}.
  * <br>
  * <br>
  * The most basic rules when writing a client API can be see below:
@@ -83,14 +79,13 @@ public interface MoccaClient {
      */
     class Builder {
 
-        private static final Logger logger = LoggerFactory.getLogger(Builder.class);
-
-        private Builder() {}
+        private Builder() {
+        }
 
         /**
-         * Provides a builder to create a Mocca sync client.
-         * If an HTTP client is not set in the builder, a {@link MoccaDefaultHttpClient} will be used.
-         * See {@link Builder.SyncBuilder#client(MoccaHttpClient)} for further information.
+         * Provides a builder to create a Mocca sync client. If an HTTP client is not set in the builder, a {@link
+         * MoccaDefaultHttpClient} will be used. See {@link Builder.SyncBuilder#client(MoccaHttpClient)} for further
+         * information.
          * <br>
          * See an example below of how to configure a sync Mocca client using OkHttp as HTTP client.
          * <br>
@@ -101,7 +96,8 @@ public interface MoccaClient {
          *     .build(BooksAppClient.class);
          * </code></pre>
          *
-         * @param serverBaseUrl GraphQL server base URL (e.g. https://your.graphql.server/context). Do not end the URI path with graphql, that is added automatically by Mocca.
+         * @param serverBaseUrl GraphQL server base URL (e.g. https://your.graphql.server/context). Do not end the URI
+         *                      path with graphql, that is added automatically by Mocca.
          * @return a {@link Builder.SyncBuilder}.
          */
         public static Builder.SyncBuilder sync(final String serverBaseUrl) {
@@ -109,11 +105,10 @@ public interface MoccaClient {
         }
 
         /**
-         * Provides a builder to create a Mocca asynchronous client.
-         * If an HTTP client is not set in the builder, a {@link MoccaDefaultHttpClient} will be used,
-         * executed by a cached thread pool executor service.
-         * See {@link Builder.AsyncBuilder#client(MoccaAsyncHttpClient)} and
-         * {@link MoccaExecutorHttpClient} for further information.
+         * Provides a builder to create a Mocca asynchronous client. If an HTTP client is not set in the builder, a
+         * {@link MoccaDefaultHttpClient} will be used, executed by a cached thread pool executor service. See {@link
+         * Builder.AsyncBuilder#client(MoccaAsyncHttpClient)} and {@link MoccaExecutorHttpClient} for further
+         * information.
          * <br>
          * See an example below of how to configure an async Mocca client using Apache HTTP client 5 as HTTP client.
          * <br>
@@ -126,7 +121,8 @@ public interface MoccaClient {
          *     .build(BooksAppClient.class);
          * </code></pre>
          *
-         * @param serverBaseUrl GraphQL server base URL (e.g. https://your.graphql.server/context). Do not end the URI path with graphql, that is added automatically by Mocca.
+         * @param serverBaseUrl GraphQL server base URL (e.g. https://your.graphql.server/context). Do not end the URI
+         *                      path with graphql, that is added automatically by Mocca.
          * @return a {@link Builder.AsyncBuilder}.
          */
         public static Builder.AsyncBuilder async(final String serverBaseUrl) {
@@ -158,9 +154,11 @@ public interface MoccaClient {
              * Sets a custom {@link MoccaHttpClient} to be used for GraphQL requests.
              * <br>
              * <br>
-             * Mocca uses behind the scenes an HTTP client to make the GraphQL calls. By default, JDK {@link java.net.HttpURLConnection} is used as HTTP client, and no additional dependency is required to use it.
+             * Mocca uses behind the scenes an HTTP client to make the GraphQL calls. By default, JDK {@link
+             * java.net.HttpURLConnection} is used as HTTP client, and no additional dependency is required to use it.
              * <br>
-             * However, if preferred, a custom HTTP client can be specified by adding an extra Mocca dependency and setting the HTTP client when creating the Mocca client builder (using method client), as seen below:
+             * However, if preferred, a custom HTTP client can be specified by adding an extra Mocca dependency and
+             * setting the HTTP client when creating the Mocca client builder (using method client), as seen below:
              * <br>
              * <pre><code>
              * BooksAppClient client = MoccaClient.Builder
@@ -169,7 +167,8 @@ public interface MoccaClient {
              *     .build(BooksAppClient.class);
              * </code></pre>
              * <br>
-             * All HTTP clients supported by Mocca are documented in the table below, along with the library to be added as dependency to the application, and the client class to be used in the Mocca builder.
+             * All HTTP clients supported by Mocca are documented in the table below, along with the library to be added
+             * as dependency to the application, and the client class to be used in the Mocca builder.
              * <br>
              * <br>
              * <table border="1">
@@ -407,8 +406,8 @@ public interface MoccaClient {
             protected abstract <C extends MoccaClient> C build(final Class<C> apiType);
 
             /**
-             * Adds a new {@link MoccaCapability} to be configured in this client builder.
-             * An example of Mocca capability would be Micrometer support, as seen in the example below.
+             * Adds a new {@link MoccaCapability} to be configured in this client builder. An example of Mocca
+             * capability would be Micrometer support, as seen in the example below.
              * <br>
              * <pre><code>
              * io.micrometer.core.instrument.simple.SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaClient.java
@@ -195,8 +195,6 @@ public interface MoccaClient {
              *     <li>A custom instance of the HTTP client could be provided as a constructor parameter to the Mocca HTTP client wrapper.</li>
              * </ol>
              * <br>
-             * Just for illustration purposes, in the example below read timeout is configured by setting it directly at the HTTP client, while connection timeout is set using Mocca builder API.
-             * <br>
              * <pre><code>
              * okhttp3.OkHttpClient okHttpClient = new OkHttpClient().newBuilder()
              *     .build();

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
@@ -100,11 +100,6 @@ public class MoccaClientBuilderTest {
         }
     }
 
-    //@Test
-    void connectTimeoutTest() throws Exception {
-        // TBD:(
-    }
-
     @Test
     public void capabilitiesRegistration() {
         class MyCap extends MoccaCapability {

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
@@ -1,54 +1,21 @@
 package com.paypal.mocca.client;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
 import com.paypal.mocca.client.sample.AsyncSampleClient;
 import com.paypal.mocca.client.sample.SampleClient;
 import feign.Feign;
-import feign.RetryableException;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.InvocationTargetException;
-import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class MoccaClientBuilderTest {
-
-    @Test(expectedExceptions = SocketTimeoutException.class)
-    void readTimeoutTest() throws Exception {
-        final WireMockServer server = new WireMockServer(options().dynamicPort());
-
-        final int readTimeout = 10;
-
-        server.stubFor(post(urlEqualTo("/read/graphql")).willReturn(
-            aResponse()
-                .withHeader("Content-Type","application/json;charset=UTF-8")
-                .withBody("{ \"data\": {}}")
-                .withChunkedDribbleDelay(5, 5 * readTimeout)));
-
-        server.start();
-        final String serverUrl = "http://localhost:" + server.port() + "/read";
-
-        try {
-            MoccaClient.Builder.sync(serverUrl)
-                .readTimeout(readTimeout)
-                .build(SampleClient.class)
-                .getOneSample("foo: \"boo\", bar: \"far\"")
-                .getFoo();
-        } catch (final RetryableException re) {
-            throw (Exception)re.getCause();
-        } finally {
-            server.stop();
-        }
-    }
 
     @Test
     void customExecutorServiceTest() throws Exception {

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientQueryTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientQueryTest.java
@@ -126,7 +126,7 @@ public class MoccaClientQueryTest {
     public void queryAsyncTest() throws Exception {
         final String queryVariables = "bar: \"far\", foo: \"boo\"";
         final AsyncSampleClient asyncClient =
-                MoccaClient.Builder.async(serverBaseUrl).connectionTimeout(100).build(AsyncSampleClient.class);
+                MoccaClient.Builder.async(serverBaseUrl).build(AsyncSampleClient.class);
         final SampleResponseDTO result = asyncClient.getOneSample(queryVariables).get(5, TimeUnit.SECONDS);
         assertEquals(result.getFoo(), "boo");
         assertEquals(result.getBar(), "far");

--- a/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/AbstractFunctionalTests.java
+++ b/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/AbstractFunctionalTests.java
@@ -32,7 +32,6 @@ public abstract class AbstractFunctionalTests extends JerseyTestNg.ContainerPerC
 
         client = MoccaClient.Builder
                 .sync(getBaseUri().toString())
-                .connectionTimeout(1000)
                 .client(new MoccaOkHttpClient(okHttpClient))
                 .build(BooksAppClient.class);
     }

--- a/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/MoccaQueryTest.java
+++ b/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/MoccaQueryTest.java
@@ -81,8 +81,6 @@ public class MoccaQueryTest extends AbstractFunctionalTests {
 
         AsyncBooksAppClient asyncClient = MoccaClient.Builder
                 .async(getBaseUri().toString())
-                .connectionTimeout(1000)
-                .readTimeout(1000)
                 .client(executorClient)
                 .build(AsyncBooksAppClient.class);
 
@@ -108,8 +106,6 @@ public class MoccaQueryTest extends AbstractFunctionalTests {
 
         AsyncBooksAppClient asyncClient = MoccaClient.Builder
                 .async(getBaseUri().toString())
-                .connectionTimeout(1000)
-                .readTimeout(1000)
                 .client(asyncHttpClient)
                 .build(AsyncBooksAppClient.class);
 

--- a/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
+++ b/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
@@ -14,7 +14,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Mocca JAXRS2 client. In order to use a JAX-RS 2 client with Mocca, create a new instance of this class and pass it to
+ * Mocca JAX-RS 2 client. In order to use a JAX-RS 2 client with Mocca, create a new instance of this class and pass it to
  * Mocca builder.
  * <br>
  * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(MoccaHttpClient)} for further information

--- a/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
+++ b/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
@@ -2,22 +2,142 @@ package com.paypal.mocca.client;
 
 import feign.jaxrs2.JAXRSClient;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configuration;
+import java.security.KeyStore;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
- * Mocca JAXRS2 client. In order to use a JAX-RS 2 client with Mocca,
- * create a new instance of this class and pass it to Mocca builder.
+ * Mocca JAXRS2 client. In order to use a JAX-RS 2 client with Mocca, create a new instance of this class and pass it to
+ * Mocca builder.
  * <br>
- * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(MoccaHttpClient)} for further information and code example.
+ * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(MoccaHttpClient)} for further information
+ * and code example.
  */
 final public class MoccaJaxrsClient extends MoccaHttpClient {
 
     /**
-     * Create a Mocca JAX-RS 2 client using the supplied {@link ClientBuilder}
+     * Create a Mocca JAX-RS 2 client using the supplied {@link Client}.
      *
-     * @param clientBuilder a JAX-RS client builder with user defined configuration
+     * @param client a JAX-RS client with user defined configuration
      */
-    public MoccaJaxrsClient(final ClientBuilder clientBuilder) {
-        super(new JAXRSClient(clientBuilder));
+    public MoccaJaxrsClient(final Client client) {
+        super(new JAXRSClient(new StubbornClientBuilder(client)));
+    }
+
+    private static class StubbornClientBuilder extends ClientBuilder {
+        private static final String USAGE_ERR_MSG = "Only #build can be called.";
+
+        final Client client;
+
+        private StubbornClientBuilder(final Client client) {
+            this.client = Arguments.requireNonNull(client);
+        }
+
+        @Override
+        public Client build() {
+            return client;
+        }
+
+        @Override
+        public ClientBuilder withConfig(Configuration config) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder sslContext(SSLContext sslContext) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder keyStore(KeyStore keyStore, char[] password) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder trustStore(KeyStore trustStore) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder hostnameVerifier(HostnameVerifier verifier) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder executorService(ExecutorService executorService) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder connectTimeout(long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder readTimeout(long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public Configuration getConfiguration() {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder property(String name, Object value) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder register(Class<?> componentClass) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder register(Class<?> componentClass, int priority) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder register(Class<?> componentClass, Class<?>... contracts) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder register(Class<?> componentClass, Map<Class<?>, Integer> contracts) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder register(Object component) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder register(Object component, int priority) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder register(Object component, Class<?>... contracts) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
+
+        @Override
+        public ClientBuilder register(Object component, Map<Class<?>, Integer> contracts) {
+            throw new UnsupportedOperationException(USAGE_ERR_MSG);
+        }
     }
 }


### PR DESCRIPTION
Short story is that we want people to configure the clients how they see fit.  We don't want feign recreating clients for things like an HTTP read timeout.  See #7 for more info.

Please do not rebase-merge.  I would like to keep the formatting commit separate.