### PR TITLE
Fixing typo in docs for MoccalClient written as JavaClient

### DIFF
--- a/docs/END_USER_DOCUMENT.md
+++ b/docs/END_USER_DOCUMENT.md
@@ -71,7 +71,7 @@ dependencies {
 
 ### 2.2 Create a client API
 
-Create a new Java interface, extend `JavaClient`, and add Mocca annotated methods to it representing all necessary GraphQL queries and mutations (according to server API), as seen in the example below.
+Create a new Java interface, extend `MoccaClient`, and add Mocca annotated methods to it representing all necessary GraphQL queries and mutations (according to server API), as seen in the example below.
 
 ``` java
 


### PR DESCRIPTION
In The end user document we have a typo in section 2.2 
The doc mentions that to create a client API we extend JavaClient whereas it should be MoccaClient