### PR TITLE
Fix timeout support #41

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,8 @@ subprojects {
 
 def feign_version = '11.5'
 
+def jetty_version = '9.2.28.v20190418'
+
 // Dependencies version management
 ext.lib = [
 
@@ -182,7 +184,8 @@ ext.lib = [
         graphql_tools: "com.graphql-java-kickstart:graphql-java-tools:6.1.0",
         
         // Jetty
-        jetty_server: "org.eclipse.jetty:jetty-server:9.2.28.v20190418",
+        jetty_server: "org.eclipse.jetty:jetty-server:" + jetty_version,
+        jetty_servlet: "org.eclipse.jetty:jetty-servlet:" + jetty_version,
 
         // Utils
         activation: 'javax.activation:activation:1.1.1',

--- a/mocca-apache/src/main/java/com/paypal/mocca/client/MoccaApacheClient.java
+++ b/mocca-apache/src/main/java/com/paypal/mocca/client/MoccaApacheClient.java
@@ -12,7 +12,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaApacheClient extends MoccaHttpClient {
+final public class MoccaApacheClient extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca Apache HTTP client using

--- a/mocca-apache/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-apache/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -4,8 +4,10 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.testng.annotations.Test;
 
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaApacheClient(HttpClientBuilder.create().build()));
+public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    MoccaHttpClient.WithRequestTimeouts create() {
+        return new MoccaApacheClient(HttpClientBuilder.create().build());
     }
 }

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaDefaultHttpClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaDefaultHttpClient.java
@@ -10,7 +10,7 @@ import java.net.HttpURLConnection;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaDefaultHttpClient extends MoccaHttpClient {
+final public class MoccaDefaultHttpClient extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca default HTTP client using

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaHttpClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaHttpClient.java
@@ -20,9 +20,25 @@ abstract class MoccaHttpClient {
 
     private final Client feignClient;
 
-    protected MoccaHttpClient(Client feignClient) {
+    // private + extensions = pseudo sealed case class in Java 8 and below.  Modeled after Optional.
+    private MoccaHttpClient(Client feignClient) {
         this.feignClient =
             Arguments.requireNonNull(feignClient, "Feign client cannot be null");
+    }
+
+    /**
+     * This is a 'marker interface'
+     */
+    abstract static class WithRequestTimeouts extends MoccaHttpClient {
+        public WithRequestTimeouts(Client feignClient) {
+            super(feignClient);
+        }
+    }
+
+    abstract static class WithoutRequestTimeouts extends MoccaHttpClient {
+        public WithoutRequestTimeouts(Client feignClient) {
+            super(feignClient);
+        }
     }
 
     /**

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
@@ -92,6 +92,7 @@ public class MoccaClientBuilderTest {
 
         try {
             MoccaClient.Builder.sync("http://localhost:8080")
+                .defaultClient()
                 .resiliency(new BadResilience())
                 .build(SampleClient.class);
             fail("Expected an exception to be the thrown.");
@@ -109,10 +110,12 @@ public class MoccaClientBuilderTest {
         }
         try {
             MoccaClient.Builder.sync("http://foo")
+                .defaultClient()
                 .addCapability(new MyCap())
                 .build(SampleClient.class);
             fail("Expected an exception caused by MyCap.");
         } catch (final Exception e) {
+            e.printStackTrace();
             assertEquals(
                 ((InvocationTargetException)e.getCause()).getTargetException().getMessage(),
                 PoorFeignCapability.errorMessage

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientMutationTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientMutationTest.java
@@ -20,7 +20,7 @@ public class MoccaClientMutationTest {
     @BeforeClass
     private void setup() throws IOException {
         String serverBaseUrl = WireMockProvider.startServer();
-        client = MoccaClient.Builder.sync(serverBaseUrl).build(SampleClient.class);
+        client = MoccaClient.Builder.sync(serverBaseUrl).defaultClient().build(SampleClient.class);
     }
 
     @AfterClass

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientQueryTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientQueryTest.java
@@ -43,7 +43,9 @@ public class MoccaClientQueryTest {
     @BeforeClass
     private void setup() throws IOException {
         serverBaseUrl = WireMockProvider.startServer();
-        client = MoccaClient.Builder.sync(serverBaseUrl).build(SampleClient.class);
+        client = MoccaClient.Builder.sync(serverBaseUrl)
+            .defaultClient()
+            .build(SampleClient.class);
     }
 
     @AfterClass
@@ -295,13 +297,17 @@ public class MoccaClientQueryTest {
 
     @Test(expectedExceptions = EncodeException.class, expectedExceptionsMessageRegExp = "Invalid GraphQL operation method noMoccaAnnotations, make sure all its parameters are annotated with one Mocca annotation")
     public void noMoccaAnnotationsTest() {
-        InvalidClient invalidClient = MoccaClient.Builder.sync("localhost").build(InvalidClient.class);
+        InvalidClient invalidClient = MoccaClient.Builder.sync("localhost")
+            .defaultClient()
+            .build(InvalidClient.class);
         invalidClient.noMoccaAnnotations("boo", "far");
     }
 
     @Test(expectedExceptions = EncodeException.class, expectedExceptionsMessageRegExp = "Invalid GraphQL operation method moreThanOneMoccaAnnotation, make sure all its parameters are annotated with one Mocca annotation")
     public void moreThanOneMoccaAnnotationTest() {
-        InvalidClient invalidClient = MoccaClient.Builder.sync("localhost").build(InvalidClient.class);
+        InvalidClient invalidClient = MoccaClient.Builder.sync("localhost")
+            .defaultClient()
+            .build(InvalidClient.class);
         invalidClient.moreThanOneMoccaAnnotation("boo", "far");
     }
 

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaDynamicHeaderTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaDynamicHeaderTest.java
@@ -10,7 +10,10 @@ public class MoccaDynamicHeaderTest {
 
     @Test(expectedExceptions = MoccaException.class, expectedExceptionsMessageRegExp = "(Header value:\\{ classvalue } at class level cannot be dynamic)")
     public void verifyDynamicHeader() {
-        DynamicHeaderClient client = MoccaClient.Builder.sync("dummyurl").build(DynamicHeaderClient.class);
+        DynamicHeaderClient client =
+            MoccaClient.Builder.sync("dummyurl")
+                .defaultClient()
+                .build(DynamicHeaderClient.class);
         String queryVariables = "foo: \"zoo\", bar: \"car\"";
         client.getOneSample(queryVariables);
     }

--- a/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/MoccaQueryTest.java
+++ b/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/MoccaQueryTest.java
@@ -46,6 +46,7 @@ public class MoccaQueryTest extends AbstractFunctionalTests {
         final SimpleMeterRegistry reg = new SimpleMeterRegistry();
         final BooksAppClient micrometerEnabledClient =
             MoccaClient.Builder.sync(getBaseUri().toString())
+                .defaultClient()
                 .addCapability(new MoccaMicrometerCapability(reg))
                 .build(BooksAppClient.class);
 
@@ -109,6 +110,7 @@ public class MoccaQueryTest extends AbstractFunctionalTests {
         final BooksAppClient client =
             MoccaClient.Builder
                 .sync(getBaseUri().toString())
+                .defaultClient()
                 .resiliency(
                     new MoccaResilience4j.Builder()
                         .circuitBreaker(circuitBreaker)

--- a/mocca-google/src/main/java/com/paypal/mocca/client/MoccaGoogleHttpClient.java
+++ b/mocca-google/src/main/java/com/paypal/mocca/client/MoccaGoogleHttpClient.java
@@ -11,7 +11,7 @@ import com.google.api.client.http.javanet.NetHttpTransport;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaGoogleHttpClient extends MoccaHttpClient {
+final public class MoccaGoogleHttpClient extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca Google HTTP client using

--- a/mocca-google/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-google/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -3,9 +3,13 @@ package com.paypal.mocca.client;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import org.testng.annotations.Test;
 
+import java.time.Duration;
+
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaGoogleHttpClient(new NetHttpTransport()));
+public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    MoccaHttpClient.WithRequestTimeouts create() {
+        return new MoccaGoogleHttpClient(new NetHttpTransport());
     }
 }

--- a/mocca-hc5/src/main/java/com/paypal/mocca/client/MoccaApache5Client.java
+++ b/mocca-hc5/src/main/java/com/paypal/mocca/client/MoccaApache5Client.java
@@ -12,7 +12,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaApache5Client extends MoccaHttpClient {
+final public class MoccaApache5Client extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca Apache 5 HTTP client using

--- a/mocca-hc5/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-hc5/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -4,8 +4,10 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.testng.annotations.Test;
 
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaApache5Client(HttpClientBuilder.create().build()));
+public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    MoccaHttpClient.WithRequestTimeouts create() {
+        return new MoccaApache5Client(HttpClientBuilder.create().build());
     }
 }

--- a/mocca-http-client-tests/build.gradle
+++ b/mocca-http-client-tests/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
     implementation project(':mocca-client'),
+                   lib.feign_core,
                    lib.jetty_server,
+                   lib.jetty_servlet,
                    lib.testng
 }

--- a/mocca-http-client-tests/src/main/java/com/paypal/mocca/client/BasicMoccaHttpClientTest.java
+++ b/mocca-http-client-tests/src/main/java/com/paypal/mocca/client/BasicMoccaHttpClientTest.java
@@ -1,18 +1,30 @@
 package com.paypal.mocca.client;
 
 import com.paypal.mocca.client.annotation.Query;
-import org.eclipse.jetty.server.Request;
+import com.paypal.mocca.client.annotation.RequestHeader;
+import com.paypal.mocca.client.annotation.RequestHeaderParam;
+import feign.RetryableException;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 /**
  * Verifies that a supplied {@link MoccaHttpClient} works for
@@ -30,32 +42,122 @@ abstract class BasicMoccaHttpClientTest {
     // https://discuss.gradle.org/t/testng-tests-that-inherit-from-a-base-class-but-do-not-add-new-test-methods-are-not-detected/1259
     // https://stackoverflow.com/questions/64087969/testng-cannot-find-test-methods-with-inheritance
 
-    private static final String GRAPHQL_GREETING = "Hello!";
+    static final String GRAPHQL_GREETING = "Hello!";
+    static final String RESPONSE_DELAY_HEADER = "ResponseDelay";
 
-    private final MoccaHttpClient moccaHttpClient;
     private Server graphqlServer;
-    private SampleDataClient sampleDataClient;
 
-    BasicMoccaHttpClientTest(MoccaHttpClient moccaHttpClient) {
-        this.moccaHttpClient = Arguments.requireNonNull(moccaHttpClient);
+    private BasicMoccaHttpClientTest() {
+    }
+
+    abstract MoccaHttpClient create();
+
+    abstract static class WithRequestTimeouts extends BasicMoccaHttpClientTest {
+        @Override
+        abstract MoccaHttpClient.WithRequestTimeouts create();
+
+        @Test(
+            description = "GraphQL call respects Mocca-builder specified HTTP read timeout (i.e. per request timeout)."
+        )
+        void testReadTimeout() {
+            final boolean followRedirects = false;
+            final Duration connectTimeout = Duration.ofSeconds(5);
+            final Duration readTimeout    = Duration.ofMillis(100);
+
+            final SampleDataClient sampleClient = syncBuilder()
+                .client(create())
+                .options(connectTimeout, readTimeout, followRedirects)
+                .build(SampleDataClient.class);
+            try {
+                sampleClient.greeting(readTimeout.multipliedBy(2).toMillis());
+                fail("Expected some form of timeout exception to be thrown.");
+            } catch (final RetryableException e) {
+                // TODO this needs the same treatment as WithoutRequestTimeouts
+                assertEquals(e.getCause().getClass(), SocketTimeoutException.class);
+            }
+        }
+    }
+
+    abstract static class WithoutRequestTimeouts extends BasicMoccaHttpClientTest {
+        @Override
+        abstract MoccaHttpClient.WithoutRequestTimeouts create();
+
+        /**
+         * @param readTimeout The maximum time to wait while waiting to read <i>a</i>
+         *                    byte from the HTTP response.
+         * @return
+         */
+        abstract TimeoutCollateral create(final Duration readTimeout);
+
+        @Test(
+            description = "GraphQL call respects HTTP read timeout."
+        )
+        void testReadTimeout() {
+            final Duration readTimeout = Duration.ofMillis(100);
+            final TimeoutCollateral timeoutCollateral = create(readTimeout);
+            final SampleDataClient sampleClient = createClient(timeoutCollateral.client);
+            try {
+                sampleClient.greeting(readTimeout.multipliedBy(2).toMillis());
+                fail("Expected some form of timeout exception to be thrown.");
+            } catch (final Exception e) {
+                timeoutCollateral.exceptionAsserter.accept(e);
+            }
+        }
+
+        /**
+         * Data we need to test HTTP timeout scenarios (e.g. max time between reading bytes).
+         */
+        static class TimeoutCollateral {
+            /**
+             * Client that will be used to make the request.
+             */
+            final MoccaHttpClient client;
+
+            /**
+             * Each implementation is responsible for determining if the thrown exception
+             * has the appropriate state.  For this, they provide this 'asserting' function.
+             */
+            final Consumer<Exception> exceptionAsserter;
+
+            TimeoutCollateral(final MoccaHttpClient client,
+                              final Consumer<Exception> exceptionAsserter) {
+                this.client = client;
+                this.exceptionAsserter = exceptionAsserter;
+            }
+        }
     }
 
     @BeforeClass
     public void setUp() throws Exception {
         final int port = 0; // signals use random port
-        graphqlServer = new Server(port);
-        graphqlServer.setHandler(new AbstractHandler() {
+        final InetSocketAddress addr = new InetSocketAddress("localhost", port);
+        graphqlServer = new Server(addr);
+
+        final ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+        graphqlServer.setHandler(context);
+
+        final Servlet greetingServlet = new HttpServlet() {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest req, HttpServletResponse resp)
-                throws IOException {
-                baseRequest.setHandled(true);
+            protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+                Optional.ofNullable(req.getHeader(RESPONSE_DELAY_HEADER))
+                    .map(Long::parseLong)
+                    .ifPresent(delay -> {
+                        try {
+                            Thread.sleep(delay);
+                        } catch (final InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                        }
+                    });
+
+                resp.setStatus(200);
                 resp.getWriter().write("{ \"data\": { \"greeting\": \"" + GRAPHQL_GREETING + "\" } }");
             }
-        });
+        };
+
+        context.addServlet(new ServletHolder(greetingServlet),"/*");
+
         graphqlServer.start();
-        sampleDataClient = MoccaClient.Builder.sync(graphqlServer.getURI().toASCIIString())
-                .client(moccaHttpClient)
-                .build(SampleDataClient.class);
     }
 
     @AfterClass
@@ -65,12 +167,40 @@ abstract class BasicMoccaHttpClientTest {
 
     @Test(description = "Basic GraphQL call")
     void testBasic() {
-        final String greeting = sampleDataClient.greeting();
+        final String greeting = createClient().greeting();
         assertEquals(greeting, GRAPHQL_GREETING);
+    }
+
+    protected SampleDataClient createClient() {
+        return createClient(create());
+    }
+
+    protected SampleDataClient createClient(final MoccaHttpClient httpClient) {
+        // This is a little bit hacky, but the general idea is the tests that leverage
+        // this function are not concerned with setting timeouts.
+        final MoccaHttpClient.WithoutRequestTimeouts clientWithoutTimeouts =
+            new MoccaHttpClient.WithoutRequestTimeouts(httpClient.getFeignClient()) {};
+
+        return syncBuilder()
+                .client(clientWithoutTimeouts)
+                .build(SampleDataClient.class);
+    }
+
+    protected MoccaClient.Builder.SyncBuilder syncBuilder() {
+        return MoccaClient.Builder.sync(graphqlServer.getURI().toASCIIString());
     }
 
     public interface SampleDataClient extends MoccaClient {
         @Query
         String greeting();
+
+        /**
+         * A delayed greeting.
+         *
+         * @param delayInMs The amount of time the server should wait before replying
+         */
+        @Query
+        @RequestHeader(RESPONSE_DELAY_HEADER + ": {delay}")
+        String greeting(@RequestHeaderParam("delay") long delayInMs);
     }
 }

--- a/mocca-http2/src/main/java/com/paypal/mocca/client/MoccaHttp2Client.java
+++ b/mocca-http2/src/main/java/com/paypal/mocca/client/MoccaHttp2Client.java
@@ -12,7 +12,7 @@ import java.net.http.HttpClient;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaHttp2Client extends MoccaHttpClient {
+final public class MoccaHttp2Client extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca Java 11 HTTP 2 client using

--- a/mocca-http2/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-http2/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -5,8 +5,10 @@ import org.testng.annotations.Test;
 import java.net.http.HttpClient;
 
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaHttp2Client(HttpClient.newBuilder().build()));
+public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    MoccaHttpClient.WithRequestTimeouts create() {
+        return new MoccaHttp2Client(HttpClient.newBuilder().build());
     }
 }

--- a/mocca-jaxrs2/build.gradle
+++ b/mocca-jaxrs2/build.gradle
@@ -7,5 +7,6 @@ dependencies {
     testImplementation project(':mocca-http-client-tests'),
                        lib.testng,
                        lib.jersey_client,
-                       lib.jersey_hk2
+                       lib.jersey_hk2,
+                       lib.activation
 }

--- a/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
+++ b/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  * request.  However, those are ignored.  The only timeouts that are used are what's established in the supplied
  * {@link Client}.
  */
-final public class MoccaJaxrsClient extends MoccaHttpClient {
+final public class MoccaJaxrsClient extends MoccaHttpClient.WithoutRequestTimeouts {
     private static Logger log = LoggerFactory.getLogger(MoccaJaxrsClient.class);
 
     /**
@@ -36,8 +36,8 @@ final public class MoccaJaxrsClient extends MoccaHttpClient {
      */
     public MoccaJaxrsClient(final Client client) {
         super(new JAXRSClient(new StubbornClientBuilder(client)));
-        log.debug("Users of this may attempt to set read timeout and connect timeout per request. " +
-            "However, those are ignored. They should be established in the supplied javax.ws.rs.Client.");
+        log.info("Mocca implementation _may_ attempt to set read timeout and connect timeout per request.  " +
+            "However, those are ignored.  They should be established in the supplied javax.ws.rs.Client.");
     }
 
     private static class StubbornClientBuilder extends ClientBuilder {
@@ -53,6 +53,16 @@ final public class MoccaJaxrsClient extends MoccaHttpClient {
         @Override
         public Client build() {
             return client;
+        }
+
+        @Override
+        public ClientBuilder connectTimeout(long timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public ClientBuilder readTimeout(long timeout, TimeUnit unit) {
+            return this;
         }
 
         @Override
@@ -94,16 +104,6 @@ final public class MoccaJaxrsClient extends MoccaHttpClient {
         @Override
         public ClientBuilder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
             log.warn(USAGE_ERR_MSG);
-            return this;
-        }
-
-        @Override
-        public ClientBuilder connectTimeout(long timeout, TimeUnit unit) {
-            return this;
-        }
-
-        @Override
-        public ClientBuilder readTimeout(long timeout, TimeUnit unit) {
             return this;
         }
 

--- a/mocca-jaxrs2/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-jaxrs2/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -2,11 +2,32 @@ package com.paypal.mocca.client;
 
 import org.testng.annotations.Test;
 
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.ClientBuilder;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
 
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaJaxrsClient(ClientBuilder.newClient()));
+public class BasicTest extends BasicMoccaHttpClientTest.WithoutRequestTimeouts {
+    @Override
+    MoccaHttpClient.WithoutRequestTimeouts create() {
+        return new MoccaJaxrsClient(ClientBuilder.newClient());
     }
+
+    @Override
+    TimeoutCollateral create(final Duration readTimeout) {
+        final MoccaHttpClient client = new MoccaJaxrsClient(
+            ClientBuilder.newBuilder()
+                .readTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                .build()
+        );
+        return new TimeoutCollateral(
+            client,
+            e -> assertEquals(e.getCause().getClass(), SocketTimeoutException.class)
+        );
+    }
+
 }

--- a/mocca-okhttp/src/main/java/com/paypal/mocca/client/MoccaOkHttpClient.java
+++ b/mocca-okhttp/src/main/java/com/paypal/mocca/client/MoccaOkHttpClient.java
@@ -8,7 +8,7 @@ package com.paypal.mocca.client;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaOkHttpClient extends MoccaHttpClient {
+final public class MoccaOkHttpClient extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca OkHttp client using

--- a/mocca-okhttp/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-okhttp/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -3,8 +3,10 @@ package com.paypal.mocca.client;
 import org.testng.annotations.Test;
 
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaOkHttpClient());
+public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    MoccaHttpClient.WithRequestTimeouts create() {
+        return new MoccaOkHttpClient();
     }
 }


### PR DESCRIPTION
See the issue for more info, but basically the code I'm replacing
assumed that:

1. Connect/read timeout was always done with client creation.
2. Our impl (technically feign) couldn't successfully set those per
   request.

This work addresses the above and 3 issues:

1. How a client can specify how the timeouts are specified.
2. How the builder chain can honor the above in a nice way (i.e if you
   a client says it doesn't support request timeouts then those aren't
   exposed via the build chain).
3. How to test without repetition.

So, it was just interesting to try and solve this.  Now, I don't think
this code is super-complicated, but I can understand distaste for this.
I primarily did it just out of interest:)  I think you could make a
decent argument that we just bring back the timeout methods to all
builder chains and in the jaxrs2+client, we'd just log that these are ignored.  
That's unfortunate, but if this is the only case where we need to ignore 
request-level timeouts, then I can understand not wanting this code.

Even if we get rid of this, there should still be some thought to whether
we do timeout tests.  I lean towards no..