### PR TITLE
Fix timeout support #41

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,8 @@ def resilience4j_feign_version = '1.7.1'
 def jersey_version = '2.35'
 def jackson_version = '2.12.6'
 
+def jetty_version = '9.2.28.v20190418'
+
 // Dependencies version management
 ext.lib = [
 
@@ -185,7 +187,8 @@ ext.lib = [
         graphql_tools: 'com.graphql-java-kickstart:graphql-java-tools:6.1.0',
         
         // Jetty
-        jetty_server: 'org.eclipse.jetty:jetty-server:9.2.28.v20190418',
+        jetty_server: "org.eclipse.jetty:jetty-server:" + jetty_version,
+        jetty_servlet: "org.eclipse.jetty:jetty-servlet:" + jetty_version,
 
         // Utils
         activation: 'javax.activation:activation:1.1.1',

--- a/mocca-apache/src/main/java/com/paypal/mocca/client/MoccaApacheClient.java
+++ b/mocca-apache/src/main/java/com/paypal/mocca/client/MoccaApacheClient.java
@@ -8,7 +8,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
  * Mocca Apache HTTP client. In order to use a Apache HTTP client with Mocca,
  * create a new instance of this class and pass it to Mocca builder.
  * <br>
- * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(MoccaHttpClient)} for further information and code example.
+ * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(WithRequestTimeouts)} for further information and code example.
  *
  * @author fabiocarvalho777@gmail.com
  */

--- a/mocca-apache/src/main/java/com/paypal/mocca/client/MoccaApacheClient.java
+++ b/mocca-apache/src/main/java/com/paypal/mocca/client/MoccaApacheClient.java
@@ -12,7 +12,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaApacheClient extends MoccaHttpClient {
+final public class MoccaApacheClient extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca Apache HTTP client using

--- a/mocca-apache/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-apache/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -4,8 +4,10 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.testng.annotations.Test;
 
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaApacheClient(HttpClientBuilder.create().build()));
+public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    MoccaHttpClient.WithRequestTimeouts create() {
+        return new MoccaApacheClient(HttpClientBuilder.create().build());
     }
 }

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaAsyncHttpClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaAsyncHttpClient.java
@@ -2,6 +2,8 @@ package com.paypal.mocca.client;
 
 import feign.AsyncClient;
 
+import java.time.Duration;
+
 /**
  * An abstract class representing an asynchronous HTTP client supported by Mocca. Subclasses are supposed
  * to work as wrappers to asynchronous HTTP clients, based on composition, and must adhere to
@@ -14,16 +16,37 @@ import feign.AsyncClient;
  *     <li>Define the generics parameter using the asynchronous HTTP client type</li>
  * </ol>
  *
- * @param <T> the asynchronous HTTP client type
+ * @param <C> an optional context
  * @author fabiocarvalho777@gmail.com
  */
-abstract class MoccaAsyncHttpClient<T> {
+abstract class MoccaAsyncHttpClient<C> {
 
-    private final AsyncClient<T> feignAsyncClient;
+    private final AsyncClient<C> feignAsyncClient;
 
-    protected MoccaAsyncHttpClient(AsyncClient<T> feignAsyncClient) {
+    private MoccaAsyncHttpClient(final AsyncClient<C> feignAsyncClient) {
         this.feignAsyncClient =
             Arguments.requireNonNull(feignAsyncClient, "Feign async client cannot be null");
+    }
+
+    /**
+     * This is a marker interface that signals to {@link MoccaClient.Builder.AsyncBuilder#client(WithRequestTimeouts)}
+     * that the supplied {@link AsyncClient} can be used with Mocca-specified timeouts, {@link MoccaClient.Builder.AsyncBuilder.WithRequestTimeouts#options(Duration, Duration, boolean)}.
+     */
+    abstract static class WithRequestTimeouts<C> extends MoccaAsyncHttpClient<C> {
+        public WithRequestTimeouts(final AsyncClient<C> feignClient) {
+            super(feignClient);
+        }
+    }
+
+    /**
+     * This is a marker interface that signals to {@link MoccaClient.Builder.AsyncBuilder#client(WithoutRequestTimeouts)}
+     * that the supplied {@link AsyncClient} cannot be used with Mocca-specified timeouts.  Timeouts should be
+     * handled by the supplied client.
+     */
+    abstract static class WithoutRequestTimeouts<C> extends MoccaAsyncHttpClient<C> {
+        public WithoutRequestTimeouts(final AsyncClient<C> feignClient) {
+            super(feignClient);
+        }
     }
 
     /**
@@ -33,7 +56,7 @@ abstract class MoccaAsyncHttpClient<T> {
      * @return a Feign client containing the asynchronous HTTP client specified in the subclass,
      * to be used in a Mocca builder when creating a Mocca client
      */
-    AsyncClient<T> getFeignAsyncClient() {
+    AsyncClient<C> getFeignAsyncClient() {
         return feignAsyncClient;
     }
 

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaAsyncHttpClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaAsyncHttpClient.java
@@ -16,14 +16,13 @@ import java.time.Duration;
  *     <li>Define the generics parameter using the asynchronous HTTP client type</li>
  * </ol>
  *
- * @param <C> an optional context
  * @author fabiocarvalho777@gmail.com
  */
-abstract class MoccaAsyncHttpClient<C> {
+abstract class MoccaAsyncHttpClient {
 
-    private final AsyncClient<C> feignAsyncClient;
+    private final AsyncClient<?> feignAsyncClient;
 
-    private MoccaAsyncHttpClient(final AsyncClient<C> feignAsyncClient) {
+    private MoccaAsyncHttpClient(final AsyncClient<?> feignAsyncClient) {
         this.feignAsyncClient =
             Arguments.requireNonNull(feignAsyncClient, "Feign async client cannot be null");
     }
@@ -32,8 +31,8 @@ abstract class MoccaAsyncHttpClient<C> {
      * This is a marker interface that signals to {@link MoccaClient.Builder.AsyncBuilder#client(WithRequestTimeouts)}
      * that the supplied {@link AsyncClient} can be used with Mocca-specified timeouts, {@link MoccaClient.Builder.AsyncBuilder.WithRequestTimeouts#options(Duration, Duration, boolean)}.
      */
-    abstract static class WithRequestTimeouts<C> extends MoccaAsyncHttpClient<C> {
-        public WithRequestTimeouts(final AsyncClient<C> feignClient) {
+    abstract static class WithRequestTimeouts extends MoccaAsyncHttpClient {
+        public WithRequestTimeouts(final AsyncClient<?> feignClient) {
             super(feignClient);
         }
     }
@@ -43,8 +42,8 @@ abstract class MoccaAsyncHttpClient<C> {
      * that the supplied {@link AsyncClient} cannot be used with Mocca-specified timeouts.  Timeouts should be
      * handled by the supplied client.
      */
-    abstract static class WithoutRequestTimeouts<C> extends MoccaAsyncHttpClient<C> {
-        public WithoutRequestTimeouts(final AsyncClient<C> feignClient) {
+    abstract static class WithoutRequestTimeouts extends MoccaAsyncHttpClient {
+        public WithoutRequestTimeouts(final AsyncClient<?> feignClient) {
             super(feignClient);
         }
     }
@@ -56,7 +55,7 @@ abstract class MoccaAsyncHttpClient<C> {
      * @return a Feign client containing the asynchronous HTTP client specified in the subclass,
      * to be used in a Mocca builder when creating a Mocca client
      */
-    AsyncClient<C> getFeignAsyncClient() {
+    AsyncClient<?> getFeignAsyncClient() {
         return feignAsyncClient;
     }
 

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaClient.java
@@ -3,9 +3,14 @@ package com.paypal.mocca.client;
 import feign.AsyncClient;
 import feign.AsyncFeign;
 import feign.Feign;
+import feign.Request;
 
+import java.time.Duration;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * Applications are supposed to create an interface, extending this one, to define their GraphQL client API. Each
@@ -147,12 +152,12 @@ public interface MoccaClient {
          * </code></pre>
          * Notice this builder is not thread-safe.
          */
-        public static class SyncBuilder extends Builder.BaseBuilder<Builder.SyncBuilder> {
+        public static class SyncBuilder  {
             private MoccaHttpClient moccaHttpClient;
-            private MoccaResiliency resiliency;
+            private final String serverBaseUrl;
 
             private SyncBuilder(final String serverBaseUrl) {
-                super(serverBaseUrl);
+                this.serverBaseUrl = Arguments.requireNonNull(serverBaseUrl);
             }
 
             /**
@@ -209,49 +214,100 @@ public interface MoccaClient {
              * @param moccaHttpClient Mocca HTTP Client
              * @return this builder
              */
-            public Builder.SyncBuilder client(final MoccaHttpClient moccaHttpClient) {
+            // TODO fix javadoc
+            public Builder.SyncBuilder.WithRequestTimeouts client(final MoccaHttpClient.WithRequestTimeouts moccaHttpClient) {
                 this.moccaHttpClient = Arguments.requireNonNull(moccaHttpClient);
-                return this;
+                return this.new WithRequestTimeouts();
             }
 
-            /**
-             * Adds a {@link MoccaResiliency} feature to be configured in this client builder.
-             *
-             * @param resiliency the resilience object to be set in this builder
-             * @return this builder
-             */
-            public SyncBuilder resiliency(final MoccaResiliency resiliency) {
-                this.resiliency = resiliency;
-                return this;
+            public Builder.SyncBuilder.WithoutRequestTimeouts client(final MoccaHttpClient.WithoutRequestTimeouts moccaHttpClient) {
+                this.moccaHttpClient = Arguments.requireNonNull(moccaHttpClient);
+                return this.new WithoutRequestTimeouts();
             }
 
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public <C extends MoccaClient> C build(final Class<C> apiType) {
-                Feign.Builder builder = (resiliency != null) ? resiliency.getFeignBuilder() : Feign.builder();
-
-                MoccaFeignEncoder encoder = new MoccaFeignEncoder();
-                builder = builder.contract(new MoccaFeignContract())
-                    .encoder(encoder)
-                    .decoder(new MoccaFeignDecoder());
-
-                if (resiliency == null) {
-                    builder.invocationHandlerFactory(new MoccaFeignInvocationHandlerFactory());
-                }
-                if (moccaHttpClient != null) {
-                    builder = builder.client(moccaHttpClient.getFeignClient());
-                }
-                for (final MoccaCapability c : capabilities) {
-                    builder = builder.addCapability(c.getFeignCapability());
-                }
-                C client =  builder.target(apiType, graphQLUrlString);
-                // the client object is needed in the encoder to perform
-                // bean validation for the request
-                encoder.setClient(client);
-                return client;
+            public Builder.SyncBuilder.WithRequestTimeouts defaultClient() {
+                return this.new WithRequestTimeouts();
             }
+
+            public class WithRequestTimeouts extends Base {
+                private Optional<Request.Options> options = Optional.empty();
+
+                public WithRequestTimeouts options(
+                    final Duration connectTimeout,
+                    final Duration readTimeout,
+                    final boolean followRedirects
+                ) {
+                    this.options = Optional.of(new Request.Options(
+                        connectTimeout.toMillis(), TimeUnit.MILLISECONDS,
+                        readTimeout.toMillis(), TimeUnit.MILLISECONDS,
+                        followRedirects
+                    ));
+                    return this;
+                }
+
+                @Override
+                protected Optional<Request.Options> options() {
+                    return this.options;
+                }
+            }
+
+            // Marker, not technically required..
+            class WithoutRequestTimeouts extends Base {}
+
+            public abstract class Base extends Builder.BaseBuilder<Builder.SyncBuilder.Base> {
+                private MoccaResiliency resiliency;
+
+                public Base() {
+                    super(serverBaseUrl);
+                }
+
+                protected Optional<Request.Options> options() {
+                    return Optional.empty();
+                }
+
+                /**
+                 * Adds a {@link MoccaResiliency} feature to be configured in this client builder.
+                 *
+                 * @param resiliency the resilience object to be set in this builder
+                 * @return this builder
+                 */
+                public Base resiliency(final MoccaResiliency resiliency) {
+                    this.resiliency = resiliency;
+                    return this;
+                }
+
+                /**
+                 * {@inheritDoc}
+                 */
+                @Override
+                public <C extends MoccaClient> C build(final Class<C> apiType) {
+                    Feign.Builder builder = (resiliency != null) ? resiliency.getFeignBuilder() : Feign.builder();
+
+                    MoccaFeignEncoder encoder = new MoccaFeignEncoder();
+                    builder = builder.contract(new MoccaFeignContract())
+                        .options(options().orElse(new Request.Options()))
+                        .encoder(encoder)
+                        .decoder(new MoccaFeignDecoder());
+
+                    if (resiliency == null) {
+                        builder.invocationHandlerFactory(new MoccaFeignInvocationHandlerFactory());
+                    }
+
+                    if (moccaHttpClient != null) {
+                        builder = builder.client(moccaHttpClient.getFeignClient());
+                    }
+                    for (final MoccaCapability c : capabilities) {
+                        builder = builder.addCapability(c.getFeignCapability());
+                    }
+                    C client =  builder.target(apiType, graphQLUrlString);
+                    // the client object is needed in the encoder to perform
+                    // bean validation for the request
+                    encoder.setClient(client);
+                    return client;
+                }
+            }
+
+
         }
 
         /**
@@ -269,6 +325,7 @@ public interface MoccaClient {
          * </code></pre>
          * Notice this builder is not thread-safe.
          */
+        // TODO Deal with client support/not-support request level timeouts
         public static class AsyncBuilder extends Builder.BaseBuilder<Builder.AsyncBuilder> {
             private MoccaAsyncHttpClient<?> moccaAsyncHttpClient;
 

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaClient.java
@@ -319,7 +319,7 @@ public interface MoccaClient {
          * Notice this builder is not thread-safe.
          */
         public static class AsyncBuilder {
-            private MoccaAsyncHttpClient<?> moccaAsyncHttpClient;
+            private MoccaAsyncHttpClient moccaAsyncHttpClient;
             private String serverBaseUrl;
 
             public AsyncBuilder(String serverBaseUrl) {
@@ -405,15 +405,14 @@ public interface MoccaClient {
              * </code></pre>
              *
              * @param moccaAsyncHttpClient Mocca HTTP asynchronous client that supports Mocca-specified timeouts.
-             * @param <CC> An optional context
              * @return a builder that supports Mocca-based timeouts.
              */
 
-            public <CC> Builder.AsyncBuilder.WithRequestTimeouts<CC> client(
-                final MoccaAsyncHttpClient.WithRequestTimeouts<CC> moccaAsyncHttpClient
+            public Builder.AsyncBuilder.WithRequestTimeouts client(
+                final MoccaAsyncHttpClient.WithRequestTimeouts moccaAsyncHttpClient
             ) {
                 this.moccaAsyncHttpClient = Arguments.requireNonNull(moccaAsyncHttpClient);
-                return this.new WithRequestTimeouts<>();
+                return this.new WithRequestTimeouts();
             }
 
             /**
@@ -421,33 +420,31 @@ public interface MoccaClient {
              * Mocca-specified timeouts.  See {@link MoccaAsyncHttpClient.WithoutRequestTimeouts} for more information.
              *
              * @param moccaAsyncHttpClient Mocca HTTP asynchronous client that does not support Mocca-specified timeouts.
-             * @param <CC> An optional context
              * @return a builder that does not support Mocca-specified timeouts.
              */
-            public <CC> Builder.AsyncBuilder.WithoutRequestTimeouts<CC> client(
-                final MoccaAsyncHttpClient.WithoutRequestTimeouts<CC> moccaAsyncHttpClient
+            public Builder.AsyncBuilder.WithoutRequestTimeouts client(
+                final MoccaAsyncHttpClient.WithoutRequestTimeouts moccaAsyncHttpClient
             ) {
                 this.moccaAsyncHttpClient = Arguments.requireNonNull(moccaAsyncHttpClient);
-                return this.new WithoutRequestTimeouts<>();
+                return this.new WithoutRequestTimeouts();
             }
 
             /**
              * Use the default HTTP asynchronous client provided by Mocca.
              *
-             * @param <CC> An optional context
              * @return a builder that supports Mocca-specified timeouts.
              */
-            public <CC> Builder.AsyncBuilder.WithRequestTimeouts<CC> defaultClient() {
-                return this.new WithRequestTimeouts<>();
+            public Builder.AsyncBuilder.WithRequestTimeouts defaultClient() {
+                return this.new WithRequestTimeouts();
             }
 
-            public Builder.AsyncBuilder client(final MoccaAsyncHttpClient<?> moccaAsyncHttpClient) {
+            public Builder.AsyncBuilder client(final MoccaAsyncHttpClient moccaAsyncHttpClient) {
                 this.moccaAsyncHttpClient = Arguments.requireNonNull(moccaAsyncHttpClient);
                 return this;
             }
 
-            public class WithRequestTimeouts<CC> extends AsyncBuilder.Base<CC, AsyncBuilder.WithRequestTimeouts<CC>> {
-                public WithRequestTimeouts<CC> options(
+            public class WithRequestTimeouts extends AsyncBuilder.Base<AsyncBuilder.WithRequestTimeouts> {
+                public WithRequestTimeouts options(
                     final Duration connectTimeout,
                     final Duration readTimeout,
                     final boolean followRedirects
@@ -458,11 +455,11 @@ public interface MoccaClient {
             }
 
             // Marker, not technically required..
-            public class WithoutRequestTimeouts<CC>
-                extends AsyncBuilder.Base<CC, AsyncBuilder.WithRequestTimeouts<CC>> {}
+            public class WithoutRequestTimeouts
+                extends AsyncBuilder.Base<AsyncBuilder.WithRequestTimeouts> {}
 
 
-            abstract class Base<CC, B extends AsyncBuilder.Base<CC, B>> extends Builder.BaseBuilder<B> {
+            abstract class Base<B extends AsyncBuilder.Base<B>> extends Builder.BaseBuilder<B> {
                 protected final OptionsBuilder optionsBuilder = new OptionsBuilder();
 
                 Base() {

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaDefaultHttpClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaDefaultHttpClient.java
@@ -10,7 +10,7 @@ import java.net.HttpURLConnection;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaDefaultHttpClient extends MoccaHttpClient {
+final public class MoccaDefaultHttpClient extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca default HTTP client using

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaExecutorHttpClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaExecutorHttpClient.java
@@ -25,10 +25,10 @@ import java.util.concurrent.ExecutorService;
  * }
  * </pre>
  *
- * @param <T> the HTTP client type
+ * @param <C> an optional context
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaExecutorHttpClient<T> extends MoccaAsyncHttpClient<T> {
+public final class MoccaExecutorHttpClient<C> extends MoccaAsyncHttpClient.WithRequestTimeouts<C> {
 
     /**
      * A Mocca async HTTP client based on a Mocca sync HTTP client

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaExecutorHttpClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaExecutorHttpClient.java
@@ -25,10 +25,9 @@ import java.util.concurrent.ExecutorService;
  * }
  * </pre>
  *
- * @param <C> an optional context
  * @author fabiocarvalho777@gmail.com
  */
-public final class MoccaExecutorHttpClient<C> extends MoccaAsyncHttpClient.WithRequestTimeouts<C> {
+public final class MoccaExecutorHttpClient extends MoccaAsyncHttpClient.WithRequestTimeouts {
 
     /**
      * A Mocca async HTTP client based on a Mocca sync HTTP client

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaHttpClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaHttpClient.java
@@ -2,6 +2,8 @@ package com.paypal.mocca.client;
 
 import feign.Client;
 
+import java.time.Duration;
+
 /**
  * An abstract class representing a synchronous HTTP client supported by Mocca. Subclasses are supposed
  * to work as wrappers to HTTP clients, based on composition, and must adhere to
@@ -27,14 +29,19 @@ abstract class MoccaHttpClient {
     }
 
     /**
-     * This is a 'marker interface'
+     * This is a marker interface that signals to {@link MoccaClient.Builder.SyncBuilder#client(WithRequestTimeouts)}
+     * that the supplied {@link Client} can be used with Mocca-specified timeouts, {@link MoccaClient.Builder.SyncBuilder.WithRequestTimeouts#options(Duration, Duration, boolean)}.
      */
     abstract static class WithRequestTimeouts extends MoccaHttpClient {
         public WithRequestTimeouts(Client feignClient) {
             super(feignClient);
         }
     }
-
+    /**
+     * This is a marker interface that signals to {@link MoccaClient.Builder.SyncBuilder#client(WithoutRequestTimeouts)}
+     * that the supplied {@link Client} cannot be used with Mocca-specified timeouts.  Timeouts should be
+     * handled by the supplied client.
+     */
     abstract static class WithoutRequestTimeouts extends MoccaHttpClient {
         public WithoutRequestTimeouts(Client feignClient) {
             super(feignClient);

--- a/mocca-client/src/main/java/com/paypal/mocca/client/MoccaHttpClient.java
+++ b/mocca-client/src/main/java/com/paypal/mocca/client/MoccaHttpClient.java
@@ -20,9 +20,25 @@ abstract class MoccaHttpClient {
 
     private final Client feignClient;
 
-    protected MoccaHttpClient(Client feignClient) {
+    // private + extensions = pseudo sealed case class in Java 8 and below.  Modeled after Optional.
+    private MoccaHttpClient(Client feignClient) {
         this.feignClient =
             Arguments.requireNonNull(feignClient, "Feign client cannot be null");
+    }
+
+    /**
+     * This is a 'marker interface'
+     */
+    abstract static class WithRequestTimeouts extends MoccaHttpClient {
+        public WithRequestTimeouts(Client feignClient) {
+            super(feignClient);
+        }
+    }
+
+    abstract static class WithoutRequestTimeouts extends MoccaHttpClient {
+        public WithoutRequestTimeouts(Client feignClient) {
+            super(feignClient);
+        }
     }
 
     /**

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
@@ -59,7 +59,7 @@ public class MoccaClientBuilderTest {
 
         final BadExecService badExecService = new BadExecService();
         final MoccaHttpClient moccaJavaHttpClient = new MoccaDefaultHttpClient();
-        final MoccaExecutorHttpClient executorHttpClient = new MoccaExecutorHttpClient(moccaJavaHttpClient, badExecService);
+        final MoccaExecutorHttpClient<?> executorHttpClient = new MoccaExecutorHttpClient<>(moccaJavaHttpClient, badExecService);
 
         try {
             MoccaClient.Builder.async("http://localhost:8080")

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
@@ -92,6 +92,7 @@ public class MoccaClientBuilderTest {
 
         try {
             MoccaClient.Builder.sync("http://localhost:8080")
+                .defaultClient()
                 .resiliency(new BadResilience())
                 .build(SampleClient.class);
             fail("Expected an exception to be the thrown.");
@@ -109,6 +110,7 @@ public class MoccaClientBuilderTest {
         }
         try {
             MoccaClient.Builder.sync("http://foo")
+                .defaultClient()
                 .addCapability(new MyCap())
                 .build(SampleClient.class);
             fail("Expected an exception caused by MyCap.");

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientBuilderTest.java
@@ -59,7 +59,7 @@ public class MoccaClientBuilderTest {
 
         final BadExecService badExecService = new BadExecService();
         final MoccaHttpClient moccaJavaHttpClient = new MoccaDefaultHttpClient();
-        final MoccaExecutorHttpClient<?> executorHttpClient = new MoccaExecutorHttpClient<>(moccaJavaHttpClient, badExecService);
+        final MoccaExecutorHttpClient executorHttpClient = new MoccaExecutorHttpClient(moccaJavaHttpClient, badExecService);
 
         try {
             MoccaClient.Builder.async("http://localhost:8080")

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientMutationTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientMutationTest.java
@@ -19,7 +19,7 @@ public class MoccaClientMutationTest {
     @BeforeClass
     private void setup() throws IOException {
         String serverBaseUrl = WireMockProvider.startServer();
-        client = MoccaClient.Builder.sync(serverBaseUrl).build(SampleClient.class);
+        client = MoccaClient.Builder.sync(serverBaseUrl).defaultClient().build(SampleClient.class);
     }
 
     @AfterClass

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientQueryTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientQueryTest.java
@@ -250,7 +250,8 @@ public class MoccaClientQueryTest {
 
     @Test
     public void queryAsyncTest() throws Exception {
-        final AsyncSampleClient asyncClient = MoccaClient.Builder.async(serverBaseUrl).build(AsyncSampleClient.class);
+        final AsyncSampleClient asyncClient =
+            MoccaClient.Builder.async(serverBaseUrl).defaultClient().build(AsyncSampleClient.class);
         final SampleResponseDTO result = asyncClient.getOneSample("boo", "far").get(5, TimeUnit.SECONDS);
         assertEquals(result.getFoo(), "boo");
         assertEquals(result.getBar(), "far");

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientQueryTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaClientQueryTest.java
@@ -44,7 +44,9 @@ public class MoccaClientQueryTest {
     @BeforeClass
     private void setup() throws IOException {
         serverBaseUrl = WireMockProvider.startServer();
-        client = MoccaClient.Builder.sync(serverBaseUrl).build(SampleClient.class);
+        client = MoccaClient.Builder.sync(serverBaseUrl)
+            .defaultClient()
+            .build(SampleClient.class);
     }
 
     @AfterClass
@@ -288,13 +290,17 @@ public class MoccaClientQueryTest {
 
     @Test(expectedExceptions = MoccaException.class, expectedExceptionsMessageRegExp = "Invalid GraphQL operation method noMoccaAnnotations, make sure all its parameters are annotated with one Mocca annotation")
     public void noMoccaAnnotationsTest() {
-        InvalidClient invalidClient = MoccaClient.Builder.sync("localhost").build(InvalidClient.class);
+        InvalidClient invalidClient = MoccaClient.Builder.sync("localhost")
+            .defaultClient()
+            .build(InvalidClient.class);
         invalidClient.noMoccaAnnotations("boo", "far");
     }
 
     @Test(expectedExceptions = MoccaException.class, expectedExceptionsMessageRegExp = "Invalid GraphQL operation method moreThanOneMoccaAnnotation, make sure all its parameters are annotated with one Mocca annotation")
     public void moreThanOneMoccaAnnotationTest() {
-        InvalidClient invalidClient = MoccaClient.Builder.sync("localhost").build(InvalidClient.class);
+        InvalidClient invalidClient = MoccaClient.Builder.sync("localhost")
+            .defaultClient()
+            .build(InvalidClient.class);
         invalidClient.moreThanOneMoccaAnnotation("boo", "far");
     }
 

--- a/mocca-client/src/test/java/com/paypal/mocca/client/MoccaDynamicHeaderTest.java
+++ b/mocca-client/src/test/java/com/paypal/mocca/client/MoccaDynamicHeaderTest.java
@@ -10,7 +10,10 @@ public class MoccaDynamicHeaderTest {
 
     @Test(expectedExceptions = MoccaException.class, expectedExceptionsMessageRegExp = "(Header value:\\{ classvalue } at class level cannot be dynamic)")
     public void verifyDynamicHeader() {
-        DynamicHeaderClient client = MoccaClient.Builder.sync("dummyurl").build(DynamicHeaderClient.class);
+        DynamicHeaderClient client =
+            MoccaClient.Builder.sync("dummyurl")
+                .defaultClient()
+                .build(DynamicHeaderClient.class);
         String queryVariables = "foo: \"zoo\", bar: \"car\"";
         client.getOneSample(queryVariables);
     }

--- a/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/MoccaQueryTest.java
+++ b/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/MoccaQueryTest.java
@@ -47,6 +47,7 @@ public class MoccaQueryTest extends AbstractFunctionalTests {
         final SimpleMeterRegistry reg = new SimpleMeterRegistry();
         final BooksAppClient micrometerEnabledClient =
             MoccaClient.Builder.sync(getBaseUri().toString())
+                .defaultClient()
                 .addCapability(new MoccaMicrometerCapability(reg))
                 .build(BooksAppClient.class);
 
@@ -110,6 +111,7 @@ public class MoccaQueryTest extends AbstractFunctionalTests {
         final BooksAppClient client =
             MoccaClient.Builder
                 .sync(getBaseUri().toString())
+                .defaultClient()
                 .resiliency(
                     new MoccaResilience4j.Builder()
                         .circuitBreaker(circuitBreaker)

--- a/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/MoccaQueryTest.java
+++ b/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/MoccaQueryTest.java
@@ -71,7 +71,7 @@ public class MoccaQueryTest extends AbstractFunctionalTests {
     @Test
     public void testBasicQueryExecutor() throws ExecutionException, InterruptedException {
         ExecutorService executorService = Executors.newCachedThreadPool();
-        MoccaExecutorHttpClient<OkHttpClient> executorClient = new MoccaExecutorHttpClient<>(new MoccaOkHttpClient(), executorService);
+        MoccaExecutorHttpClient executorClient = new MoccaExecutorHttpClient(new MoccaOkHttpClient(), executorService);
 
         AsyncBooksAppClient asyncClient = MoccaClient.Builder
                 .async(getBaseUri().toString())

--- a/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/MoccaQueryTest.java
+++ b/mocca-functional-tests/src/test/java/com/paypal/mocca/functional/MoccaQueryTest.java
@@ -137,6 +137,7 @@ public class MoccaQueryTest extends AbstractFunctionalTests {
     public void testResilientBeanValidationQuery() {
         MoccaClient.Builder
                 .sync(getBaseUri().toString())
+                .defaultClient()
                 .resiliency(new MoccaResilience4j.Builder().build())
                 .build(BooksAppClient.class)
                 .addAuthor(null);

--- a/mocca-google/src/main/java/com/paypal/mocca/client/MoccaGoogleHttpClient.java
+++ b/mocca-google/src/main/java/com/paypal/mocca/client/MoccaGoogleHttpClient.java
@@ -11,7 +11,7 @@ import com.google.api.client.http.javanet.NetHttpTransport;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaGoogleHttpClient extends MoccaHttpClient {
+final public class MoccaGoogleHttpClient extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca Google HTTP client using

--- a/mocca-google/src/main/java/com/paypal/mocca/client/MoccaGoogleHttpClient.java
+++ b/mocca-google/src/main/java/com/paypal/mocca/client/MoccaGoogleHttpClient.java
@@ -7,7 +7,8 @@ import com.google.api.client.http.javanet.NetHttpTransport;
  * Mocca Google HTTP client. In order to use a Google HTTP client with Mocca,
  * create a new instance of this class and pass it to Mocca builder.
  * <br>
- * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(MoccaHttpClient)} for further information and code example.
+ * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(WithRequestTimeouts)} for further
+ * information and code example.
  *
  * @author fabiocarvalho777@gmail.com
  */

--- a/mocca-google/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-google/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -3,9 +3,13 @@ package com.paypal.mocca.client;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import org.testng.annotations.Test;
 
+import java.time.Duration;
+
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaGoogleHttpClient(new NetHttpTransport()));
+public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    MoccaHttpClient.WithRequestTimeouts create() {
+        return new MoccaGoogleHttpClient(new NetHttpTransport());
     }
 }

--- a/mocca-google/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-google/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -3,8 +3,6 @@ package com.paypal.mocca.client;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import org.testng.annotations.Test;
 
-import java.time.Duration;
-
 @Test
 public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
 

--- a/mocca-hc5/src/main/java/com/paypal/mocca/client/MoccaApache5Client.java
+++ b/mocca-hc5/src/main/java/com/paypal/mocca/client/MoccaApache5Client.java
@@ -8,7 +8,8 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
  * Mocca Apache 5 HTTP client. In order to use a Apache 5 HTTP client with Mocca,
  * create a new instance of this class and pass it to Mocca builder.
  * <br>
- * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(MoccaHttpClient)} for further information and code example.
+ * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(WithRequestTimeouts)} 
+ * for further information and code example.
  *
  * @author fabiocarvalho777@gmail.com
  */

--- a/mocca-hc5/src/main/java/com/paypal/mocca/client/MoccaApache5Client.java
+++ b/mocca-hc5/src/main/java/com/paypal/mocca/client/MoccaApache5Client.java
@@ -12,7 +12,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaApache5Client extends MoccaHttpClient {
+final public class MoccaApache5Client extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca Apache 5 HTTP client using

--- a/mocca-hc5/src/main/java/com/paypal/mocca/client/MoccaAsyncApache5Client.java
+++ b/mocca-hc5/src/main/java/com/paypal/mocca/client/MoccaAsyncApache5Client.java
@@ -13,7 +13,7 @@ import org.apache.hc.client5.http.protocol.HttpClientContext;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaAsyncApache5Client extends MoccaAsyncHttpClient.WithRequestTimeouts<HttpClientContext> {
+final public class MoccaAsyncApache5Client extends MoccaAsyncHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca Async Apache 5 HTTP client using

--- a/mocca-hc5/src/main/java/com/paypal/mocca/client/MoccaAsyncApache5Client.java
+++ b/mocca-hc5/src/main/java/com/paypal/mocca/client/MoccaAsyncApache5Client.java
@@ -13,7 +13,7 @@ import org.apache.hc.client5.http.protocol.HttpClientContext;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaAsyncApache5Client extends MoccaAsyncHttpClient<HttpClientContext> {
+final public class MoccaAsyncApache5Client extends MoccaAsyncHttpClient.WithRequestTimeouts<HttpClientContext> {
 
     /**
      * Creates a new Mocca Async Apache 5 HTTP client using

--- a/mocca-hc5/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-hc5/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -4,8 +4,10 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.testng.annotations.Test;
 
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaApache5Client(HttpClientBuilder.create().build()));
+public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    MoccaHttpClient.WithRequestTimeouts create() {
+        return new MoccaApache5Client(HttpClientBuilder.create().build());
     }
 }

--- a/mocca-hc5/src/test/java/com/paypal/mocca/client/MoccaAsyncApache5ClientTest.java
+++ b/mocca-hc5/src/test/java/com/paypal/mocca/client/MoccaAsyncApache5ClientTest.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 @Test
 public class MoccaAsyncApache5ClientTest extends BasicMoccaAsyncHttpClientTest.WithRequestTimeouts {
     @Override
-    MoccaAsyncHttpClient.WithRequestTimeouts<?> create() {
+    MoccaAsyncHttpClient.WithRequestTimeouts create() {
         return new MoccaAsyncApache5Client();
     }
 }

--- a/mocca-hc5/src/test/java/com/paypal/mocca/client/MoccaAsyncApache5ClientTest.java
+++ b/mocca-hc5/src/test/java/com/paypal/mocca/client/MoccaAsyncApache5ClientTest.java
@@ -1,0 +1,11 @@
+package com.paypal.mocca.client;
+
+import org.testng.annotations.Test;
+
+@Test
+public class MoccaAsyncApache5ClientTest extends BasicMoccaAsyncHttpClientTest.WithRequestTimeouts {
+    @Override
+    MoccaAsyncHttpClient.WithRequestTimeouts<?> create() {
+        return new MoccaAsyncApache5Client();
+    }
+}

--- a/mocca-http-client-tests/build.gradle
+++ b/mocca-http-client-tests/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
     implementation project(':mocca-client'),
+                   lib.feign_core,
                    lib.jetty_server,
+                   lib.jetty_servlet,
                    lib.testng
 }

--- a/mocca-http-client-tests/src/main/java/com/paypal/mocca/client/BasicMoccaAsyncHttpClientTest.java
+++ b/mocca-http-client-tests/src/main/java/com/paypal/mocca/client/BasicMoccaAsyncHttpClientTest.java
@@ -34,12 +34,12 @@ abstract class BasicMoccaAsyncHttpClientTest extends WithGraphQLServer {
     private BasicMoccaAsyncHttpClientTest() {
     }
 
-    abstract <C> MoccaAsyncHttpClient<C> create();
+    abstract MoccaAsyncHttpClient create();
 
     abstract static class WithRequestTimeouts extends BasicMoccaAsyncHttpClientTest {
 
         @Override
-        abstract <C> MoccaAsyncHttpClient.WithRequestTimeouts<C> create();
+        abstract MoccaAsyncHttpClient.WithRequestTimeouts create();
 
         /**
          * In read timeout scenarios that feign manages, it is expected that the underlying
@@ -76,7 +76,7 @@ abstract class BasicMoccaAsyncHttpClientTest extends WithGraphQLServer {
 
     abstract static class WithoutRequestTimeouts extends BasicMoccaAsyncHttpClientTest {
         @Override
-        abstract <C> MoccaAsyncHttpClient.WithoutRequestTimeouts<C> create();
+        abstract MoccaAsyncHttpClient.WithoutRequestTimeouts create();
 
         /**
          * @param readTimeout The maximum time to wait while waiting to read <i>a</i>
@@ -107,7 +107,7 @@ abstract class BasicMoccaAsyncHttpClientTest extends WithGraphQLServer {
             /**
              * Client that will be used to make the request.
              */
-            final MoccaAsyncHttpClient<C> client;
+            final MoccaAsyncHttpClient client;
 
             /**
              * Each implementation is responsible for determining if the thrown exception
@@ -115,7 +115,7 @@ abstract class BasicMoccaAsyncHttpClientTest extends WithGraphQLServer {
              */
             final Consumer<Exception> exceptionAsserter;
 
-            TimeoutCollateral(final MoccaAsyncHttpClient<C> client,
+            TimeoutCollateral(final MoccaAsyncHttpClient client,
                               final Consumer<Exception> exceptionAsserter) {
                 this.client = client;
                 this.exceptionAsserter = exceptionAsserter;
@@ -133,16 +133,16 @@ abstract class BasicMoccaAsyncHttpClientTest extends WithGraphQLServer {
         return createClient(create());
     }
 
-    protected <C> SampleDataClient createClient(final MoccaAsyncHttpClient<C> httpClient) {
+    protected SampleDataClient createClient(final MoccaAsyncHttpClient httpClient) {
         // This is a little bit hacky, but the general idea is the tests that leverage
         // this function are not concerned with setting timeouts.
-        class MyClient extends MoccaAsyncHttpClient.WithoutRequestTimeouts<C> {
-            public MyClient(AsyncClient<C> feignClient) {
+        class MyClient extends MoccaAsyncHttpClient.WithoutRequestTimeouts {
+            public MyClient(AsyncClient<?> feignClient) {
                 super(feignClient);
             }
         }
 
-        final MoccaAsyncHttpClient.WithoutRequestTimeouts<?> clientWithoutTimeouts =
+        final MoccaAsyncHttpClient.WithoutRequestTimeouts clientWithoutTimeouts =
             new MyClient(httpClient.getFeignAsyncClient());
 
         return asyncBuilder()

--- a/mocca-http-client-tests/src/main/java/com/paypal/mocca/client/BasicMoccaHttpClientTest.java
+++ b/mocca-http-client-tests/src/main/java/com/paypal/mocca/client/BasicMoccaHttpClientTest.java
@@ -1,18 +1,30 @@
 package com.paypal.mocca.client;
 
 import com.paypal.mocca.client.annotation.Query;
-import org.eclipse.jetty.server.Request;
+import com.paypal.mocca.client.annotation.RequestHeader;
+import com.paypal.mocca.client.annotation.RequestHeaderParam;
+import feign.RetryableException;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 /**
  * Verifies that a supplied {@link MoccaHttpClient} works for
@@ -30,32 +42,122 @@ abstract class BasicMoccaHttpClientTest {
     // https://discuss.gradle.org/t/testng-tests-that-inherit-from-a-base-class-but-do-not-add-new-test-methods-are-not-detected/1259
     // https://stackoverflow.com/questions/64087969/testng-cannot-find-test-methods-with-inheritance
 
-    private static final String GRAPHQL_GREETING = "Hello!";
+    static final String GRAPHQL_GREETING = "Hello!";
+    static final String RESPONSE_DELAY_HEADER = "ResponseDelay";
 
-    private final MoccaHttpClient moccaHttpClient;
     private Server graphqlServer;
-    private SampleDataClient sampleDataClient;
 
-    BasicMoccaHttpClientTest(MoccaHttpClient moccaHttpClient) {
-        this.moccaHttpClient = Arguments.requireNonNull(moccaHttpClient);
+    private BasicMoccaHttpClientTest() {
+    }
+
+    abstract MoccaHttpClient create();
+
+    abstract static class WithRequestTimeouts extends BasicMoccaHttpClientTest {
+        @Override
+        abstract MoccaHttpClient.WithRequestTimeouts create();
+
+        @Test(
+            description = "GraphQL call respects Mocca-builder specified HTTP read timeout (i.e. per request timeout)."
+        )
+        void testReadTimeout() {
+            final boolean followRedirects = false;
+            final Duration connectTimeout = Duration.ofSeconds(5);
+            final Duration readTimeout    = Duration.ofMillis(100);
+
+            final SampleDataClient sampleClient = syncBuilder()
+                .client(create())
+                .options(connectTimeout, readTimeout, followRedirects)
+                .build(SampleDataClient.class);
+            try {
+                sampleClient.greeting(readTimeout.multipliedBy(2).toMillis());
+                fail("Expected some form of timeout exception to be thrown.");
+            } catch (final RetryableException e) {
+                // TODO this needs the same treatment as WithoutRequestTimeouts
+                assertEquals(e.getCause().getClass(), SocketTimeoutException.class);
+            }
+        }
+    }
+
+    abstract static class WithoutRequestTimeouts extends BasicMoccaHttpClientTest {
+        @Override
+        abstract MoccaHttpClient.WithoutRequestTimeouts create();
+
+        /**
+         * @param readTimeout The maximum time to wait while waiting to read <i>a</i>
+         *                    byte from the HTTP response.
+         * @return
+         */
+        abstract TimeoutCollateral create(final Duration readTimeout);
+
+        @Test(
+            description = "GraphQL call respects HTTP read timeout."
+        )
+        void testReadTimeout() {
+            final Duration readTimeout = Duration.ofMillis(100);
+            final TimeoutCollateral timeoutCollateral = create(readTimeout);
+            final SampleDataClient sampleClient = createClient(timeoutCollateral.client);
+            try {
+                sampleClient.greeting(readTimeout.multipliedBy(2).toMillis());
+                fail("Expected some form of timeout exception to be thrown.");
+            } catch (final Exception e) {
+                timeoutCollateral.exceptionAsserter.accept(e);
+            }
+        }
+
+        /**
+         * Data we need to test HTTP timeout scenarios (e.g. max time between reading bytes).
+         */
+        static class TimeoutCollateral {
+            /**
+             * Client that will be used to make the request.
+             */
+            final MoccaHttpClient client;
+
+            /**
+             * Each implementation is responsible for determining if the thrown exception
+             * has the appropriate state.  For this, they provide this 'asserting' function.
+             */
+            final Consumer<Exception> exceptionAsserter;
+
+            TimeoutCollateral(final MoccaHttpClient client,
+                              final Consumer<Exception> exceptionAsserter) {
+                this.client = client;
+                this.exceptionAsserter = exceptionAsserter;
+            }
+        }
     }
 
     @BeforeClass
     public void setUp() throws Exception {
         final int port = 0; // signals use random port
-        graphqlServer = new Server(port);
-        graphqlServer.setHandler(new AbstractHandler() {
+        final InetSocketAddress addr = new InetSocketAddress("localhost", port);
+        graphqlServer = new Server(addr);
+
+        final ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+        graphqlServer.setHandler(context);
+
+        final Servlet greetingServlet = new HttpServlet() {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest req, HttpServletResponse resp)
-                throws IOException {
-                baseRequest.setHandled(true);
+            protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+                Optional.ofNullable(req.getHeader(RESPONSE_DELAY_HEADER))
+                    .map(Long::parseLong)
+                    .ifPresent(delay -> {
+                        try {
+                            Thread.sleep(delay);
+                        } catch (final InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                        }
+                    });
+
+                resp.setStatus(200);
                 resp.getWriter().write("{ \"data\": { \"greeting\": \"" + GRAPHQL_GREETING + "\" } }");
             }
-        });
+        };
+
+        context.addServlet(new ServletHolder(greetingServlet),"/*");
+
         graphqlServer.start();
-        sampleDataClient = MoccaClient.Builder.sync(graphqlServer.getURI().toASCIIString())
-                .client(moccaHttpClient)
-                .build(SampleDataClient.class);
     }
 
     @AfterClass
@@ -65,12 +167,40 @@ abstract class BasicMoccaHttpClientTest {
 
     @Test(description = "Basic GraphQL call")
     void testBasic() {
-        final String greeting = sampleDataClient.greeting();
+        final String greeting = createClient().greeting();
         assertEquals(greeting, GRAPHQL_GREETING);
+    }
+
+    protected SampleDataClient createClient() {
+        return createClient(create());
+    }
+
+    protected SampleDataClient createClient(final MoccaHttpClient httpClient) {
+        // This is a little bit hacky, but the general idea is the tests that leverage
+        // this function are not concerned with setting timeouts.
+        final MoccaHttpClient.WithoutRequestTimeouts clientWithoutTimeouts =
+            new MoccaHttpClient.WithoutRequestTimeouts(httpClient.getFeignClient()) {};
+
+        return syncBuilder()
+                .client(clientWithoutTimeouts)
+                .build(SampleDataClient.class);
+    }
+
+    protected MoccaClient.Builder.SyncBuilder syncBuilder() {
+        return MoccaClient.Builder.sync(graphqlServer.getURI().toASCIIString());
     }
 
     public interface SampleDataClient extends MoccaClient {
         @Query
         String greeting();
+
+        /**
+         * A delayed greeting.
+         *
+         * @param delayInMs The amount of time the server should wait before replying
+         */
+        @Query
+        @RequestHeader(RESPONSE_DELAY_HEADER + ": {delay}")
+        String greeting(@RequestHeaderParam("delay") long delayInMs);
     }
 }

--- a/mocca-http-client-tests/src/main/java/com/paypal/mocca/client/BasicMoccaHttpClientTest.java
+++ b/mocca-http-client-tests/src/main/java/com/paypal/mocca/client/BasicMoccaHttpClientTest.java
@@ -78,11 +78,12 @@ abstract class BasicMoccaHttpClientTest extends WithGraphQLServer {
             try {
                 sampleClient.greeting(readTimeout.multipliedBy(2).toMillis());
                 fail("Expected some form of timeout exception to be thrown.");
-            } catch (final RetryableException e) {
+            } catch (final MoccaException e) {
                 // TODO how does feign know that a request timeout scenario means you can safely
                 // retry the request?  If the server has received any of the request, I don't think
                 // that's valid.  Consider writing up a feign bug.
-                assertEquals(e.getCause().getClass(), expectedTimeoutExceptionCause());
+                assertEquals(e.getCause().getClass(), RetryableException.class);
+                assertEquals(e.getCause().getCause().getClass(), expectedTimeoutExceptionCause());
             }
         }
     }

--- a/mocca-http-client-tests/src/main/java/com/paypal/mocca/client/WithGraphQLServer.java
+++ b/mocca-http-client-tests/src/main/java/com/paypal/mocca/client/WithGraphQLServer.java
@@ -1,0 +1,60 @@
+package com.paypal.mocca.client;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
+class WithGraphQLServer {
+    static final String GRAPHQL_GREETING = "Hello!";
+    static final String RESPONSE_DELAY_HEADER = "ResponseDelay";
+
+    protected Server graphqlServer;
+
+    @BeforeClass
+    public void setUp() throws Exception {
+        final int port = 0; // signals use random port
+        final InetSocketAddress addr = new InetSocketAddress("localhost", port);
+        graphqlServer = new Server(addr);
+
+        final ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+        graphqlServer.setHandler(context);
+
+        final Servlet greetingServlet = new HttpServlet() {
+            @Override
+            protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+                Optional.ofNullable(req.getHeader(RESPONSE_DELAY_HEADER))
+                    .map(Long::parseLong)
+                    .ifPresent(delay -> {
+                        try {
+                            Thread.sleep(delay);
+                        } catch (final InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                        }
+                    });
+
+                resp.setStatus(200);
+                resp.getWriter().write("{ \"data\": { \"greeting\": \"" + GRAPHQL_GREETING + "\" } }");
+            }
+        };
+
+        context.addServlet(new ServletHolder(greetingServlet),"/*");
+
+        graphqlServer.start();
+    }
+
+    @AfterClass
+    public void tearDown() throws Exception {
+        graphqlServer.stop();
+    }
+}

--- a/mocca-http2/src/main/java/com/paypal/mocca/client/MoccaHttp2Client.java
+++ b/mocca-http2/src/main/java/com/paypal/mocca/client/MoccaHttp2Client.java
@@ -2,13 +2,14 @@ package com.paypal.mocca.client;
 
 import feign.http2client.Http2Client;
 
+import java.net.SocketTimeoutException;
 import java.net.http.HttpClient;
 
 /**
  * Mocca Java 11 HTTP 2 client. In order to use a Java 11 HTTP 2 client with Mocca,
  * create a new instance of this class and pass it to Mocca builder.
  * <br>
- * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(MoccaHttpClient)} for further information and code example.
+ * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(WithRequestTimeouts)} for further information and code example.
  *
  * @author fabiocarvalho777@gmail.com
  */

--- a/mocca-http2/src/main/java/com/paypal/mocca/client/MoccaHttp2Client.java
+++ b/mocca-http2/src/main/java/com/paypal/mocca/client/MoccaHttp2Client.java
@@ -12,7 +12,7 @@ import java.net.http.HttpClient;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaHttp2Client extends MoccaHttpClient {
+final public class MoccaHttp2Client extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca Java 11 HTTP 2 client using

--- a/mocca-http2/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-http2/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -5,8 +5,10 @@ import org.testng.annotations.Test;
 import java.net.http.HttpClient;
 
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaHttp2Client(HttpClient.newBuilder().build()));
+public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    MoccaHttpClient.WithRequestTimeouts create() {
+        return new MoccaHttp2Client(HttpClient.newBuilder().build());
     }
 }

--- a/mocca-http2/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-http2/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -3,9 +3,15 @@ package com.paypal.mocca.client;
 import org.testng.annotations.Test;
 
 import java.net.http.HttpClient;
+import java.net.http.HttpTimeoutException;
 
 @Test
 public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    protected Class<?> expectedTimeoutExceptionCause() {
+        return HttpTimeoutException.class;
+    }
 
     @Override
     MoccaHttpClient.WithRequestTimeouts create() {

--- a/mocca-jaxrs2/build.gradle
+++ b/mocca-jaxrs2/build.gradle
@@ -7,6 +7,5 @@ dependencies {
     testImplementation project(':mocca-http-client-tests'),
                        lib.testng,
                        lib.jersey_client,
-                       lib.jersey_hk2,
-                       lib.activation
+                       lib.jersey_hk2
 }

--- a/mocca-jaxrs2/build.gradle
+++ b/mocca-jaxrs2/build.gradle
@@ -7,5 +7,6 @@ dependencies {
     testImplementation project(':mocca-http-client-tests'),
                        lib.testng,
                        lib.jersey_client,
-                       lib.jersey_hk2
+                       lib.jersey_hk2,
+                       lib.activation
 }

--- a/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
+++ b/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
@@ -38,7 +38,7 @@ final public class MoccaJaxrsClient extends MoccaHttpClient.WithoutRequestTimeou
     }
 
     private static class StubbornClientBuilder extends ClientBuilder {
-        private static Logger log = LoggerFactory.getLogger(StubbornClientBuilder.class);
+        private static final Logger log = LoggerFactory.getLogger(StubbornClientBuilder.class);
         private static final String USAGE_ERR_MSG = "Only #build can be called.";
 
         private final Client client;

--- a/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
+++ b/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  * request.  However, those are ignored.  The only timeouts that are used are what's established in the supplied
  * {@link Client}.
  */
-final public class MoccaJaxrsClient extends MoccaHttpClient {
+final public class MoccaJaxrsClient extends MoccaHttpClient.WithoutRequestTimeouts {
     private static Logger log = LoggerFactory.getLogger(MoccaJaxrsClient.class);
 
     /**
@@ -36,8 +36,8 @@ final public class MoccaJaxrsClient extends MoccaHttpClient {
      */
     public MoccaJaxrsClient(final Client client) {
         super(new JAXRSClient(new StubbornClientBuilder(client)));
-        log.debug("Users of this may attempt to set read timeout and connect timeout per request. " +
-            "However, those are ignored. They should be established in the supplied javax.ws.rs.Client.");
+        log.info("Mocca implementation _may_ attempt to set read timeout and connect timeout per request.  " +
+            "However, those are ignored.  They should be established in the supplied javax.ws.rs.Client.");
     }
 
     private static class StubbornClientBuilder extends ClientBuilder {
@@ -53,6 +53,16 @@ final public class MoccaJaxrsClient extends MoccaHttpClient {
         @Override
         public Client build() {
             return client;
+        }
+
+        @Override
+        public ClientBuilder connectTimeout(long timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public ClientBuilder readTimeout(long timeout, TimeUnit unit) {
+            return this;
         }
 
         @Override
@@ -94,16 +104,6 @@ final public class MoccaJaxrsClient extends MoccaHttpClient {
         @Override
         public ClientBuilder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
             log.warn(USAGE_ERR_MSG);
-            return this;
-        }
-
-        @Override
-        public ClientBuilder connectTimeout(long timeout, TimeUnit unit) {
-            return this;
-        }
-
-        @Override
-        public ClientBuilder readTimeout(long timeout, TimeUnit unit) {
             return this;
         }
 

--- a/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
+++ b/mocca-jaxrs2/src/main/java/com/paypal/mocca/client/MoccaJaxrsClient.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
  * Mocca JAX-RS 2 client. In order to use a JAX-RS 2 client with Mocca, create a new instance of this class and pass it
  * to Mocca builder.
  * <br>
- * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(MoccaHttpClient)} for further information
+ * See {@link com.paypal.mocca.client.MoccaClient.Builder.SyncBuilder#client(WithoutRequestTimeouts)} for further information
  * and code example.
  * <br>
  * Instances of this class are technically supposed to support concepts like setting the read and connect timeouts per
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
  * {@link Client}.
  */
 final public class MoccaJaxrsClient extends MoccaHttpClient.WithoutRequestTimeouts {
-    private static Logger log = LoggerFactory.getLogger(MoccaJaxrsClient.class);
 
     /**
      * Create a Mocca JAX-RS 2 client using the supplied {@link Client}.
@@ -36,8 +35,6 @@ final public class MoccaJaxrsClient extends MoccaHttpClient.WithoutRequestTimeou
      */
     public MoccaJaxrsClient(final Client client) {
         super(new JAXRSClient(new StubbornClientBuilder(client)));
-        log.info("Mocca implementation _may_ attempt to set read timeout and connect timeout per request.  " +
-            "However, those are ignored.  They should be established in the supplied javax.ws.rs.Client.");
     }
 
     private static class StubbornClientBuilder extends ClientBuilder {

--- a/mocca-jaxrs2/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-jaxrs2/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -2,11 +2,32 @@ package com.paypal.mocca.client;
 
 import org.testng.annotations.Test;
 
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.ClientBuilder;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
 
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaJaxrsClient(ClientBuilder.newClient()));
+public class BasicTest extends BasicMoccaHttpClientTest.WithoutRequestTimeouts {
+    @Override
+    MoccaHttpClient.WithoutRequestTimeouts create() {
+        return new MoccaJaxrsClient(ClientBuilder.newClient());
     }
+
+    @Override
+    TimeoutCollateral create(final Duration readTimeout) {
+        final MoccaHttpClient client = new MoccaJaxrsClient(
+            ClientBuilder.newBuilder()
+                .readTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                .build()
+        );
+        return new TimeoutCollateral(
+            client,
+            e -> assertEquals(e.getCause().getClass(), SocketTimeoutException.class)
+        );
+    }
+
 }

--- a/mocca-okhttp/src/main/java/com/paypal/mocca/client/MoccaOkHttpClient.java
+++ b/mocca-okhttp/src/main/java/com/paypal/mocca/client/MoccaOkHttpClient.java
@@ -8,7 +8,7 @@ package com.paypal.mocca.client;
  *
  * @author fabiocarvalho777@gmail.com
  */
-final public class MoccaOkHttpClient extends MoccaHttpClient {
+final public class MoccaOkHttpClient extends MoccaHttpClient.WithRequestTimeouts {
 
     /**
      * Creates a new Mocca OkHttp client using

--- a/mocca-okhttp/src/test/java/com/paypal/mocca/client/BasicTest.java
+++ b/mocca-okhttp/src/test/java/com/paypal/mocca/client/BasicTest.java
@@ -3,8 +3,10 @@ package com.paypal.mocca.client;
 import org.testng.annotations.Test;
 
 @Test
-public class BasicTest extends BasicMoccaHttpClientTest {
-    public BasicTest() {
-        super(new MoccaOkHttpClient());
+public class BasicTest extends BasicMoccaHttpClientTest.WithRequestTimeouts {
+
+    @Override
+    MoccaHttpClient.WithRequestTimeouts create() {
+        return new MoccaOkHttpClient();
     }
 }


### PR DESCRIPTION
See the issue for more info, but basically the code I'm replacing
assumed that:

1. Connect/read timeout was always done with client creation.
2. Our impl (technically feign) couldn't successfully set those per
   request.

This work addresses the above and 3 issues:

1. How a client can specify how the timeouts are specified.
2. How the builder chain can honor the above in a nice way (i.e if you
   a client says it doesn't support request timeouts then those aren't
   exposed via the build chain.
3. How to test without repetition.

So, it was just interesting to try and solve this.  Now, I don't think
this code is super-complicated, but I can understand distaste for this.
I primarily did it just out of interest:)  I think you could make a
decent argument that we just bring back the timeout methods to all
builder chains and in the jaxrs2+client (we could still add a builder
option), we'd just log that these are ignored.  That's unfortunate, but
if this is the only case where we need to ignore request-level timeouts,
then I can understand not wanting this code.