### PR TITLE
Exposing Feign to applications during compilation time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ Set testModules = [
 subprojects {
 
     group = 'com.paypal.mocca'
-    version = '0.0.3'
+    version = '0.0.4-SNAPSHOT'
 
     apply plugin: 'java-library'
     apply plugin: 'pmd'

--- a/docs/END_USER_DOCUMENT.md
+++ b/docs/END_USER_DOCUMENT.md
@@ -3,7 +3,7 @@
 <div style="text-align:center"><img src="img/logo/mocca_logo_horizontal_lightbluebackground.png" style="background-color:#27a1f2; padding:40px;"/></div>
 <br>
 
-# Mocca end user documentation (version 0.0.3)
+# Mocca end user documentation (version 0.0.4)
 
 ## Summary
 
@@ -53,12 +53,12 @@ This section shows a simple example of how to use Mocca for a quick start. For f
 
 ### 2.1 Add mocca-client dependency
 
-Add dependency `com.paypal.mocca:mocca-client:0.0.3` to your application, as shown below (examples for Maven and Gradle).
+Add dependency `com.paypal.mocca:mocca-client:0.0.4` to your application, as shown below (examples for Maven and Gradle).
 
 ``` Groovy
 // Adding Mocca in Gradle
 dependencies {
-    compile 'com.paypal.mocca:mocca-client:0.0.3'
+    compile 'com.paypal.mocca:mocca-client:0.0.4'
 }
 ```
 
@@ -67,7 +67,7 @@ dependencies {
 <dependency>
     <groupId>com.paypal.mocca</groupId>
     <artifactId>mocca-client</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
 </dependency> 
 ```
 
@@ -119,12 +119,12 @@ For more information about how to use Mocca, using specific HTTP clients, asynch
 
 ## 3 Client dependencies
 
-The main dependency needed to use Mocca is `com.paypal.mocca:mocca-client:0.0.3`. Below you can see two examples of how to add it to your application, depending on whether you use Gradle or Maven. Other Mocca dependencies may be necessary, depending on the application needs, and will be covered in other sections.
+The main dependency needed to use Mocca is `com.paypal.mocca:mocca-client:0.0.4`. Below you can see two examples of how to add it to your application, depending on whether you use Gradle or Maven. Other Mocca dependencies may be necessary, depending on the application needs, and will be covered in other sections.
 
 ``` Groovy
 // Adding Mocca in Gradle
 dependencies {
-    compile 'com.paypal.mocca:mocca-client:0.0.3'
+    compile 'com.paypal.mocca:mocca-client:0.0.4'
 }
 ```
 
@@ -133,7 +133,7 @@ dependencies {
 <dependency>
     <groupId>com.paypal.mocca</groupId>
     <artifactId>mocca-client</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
 </dependency> 
 ```
 
@@ -521,12 +521,12 @@ All HTTP clients supported by Mocca are documented in the table below, along wit
 
 | HTTP client  | Dependency | Client class | Notes |
 | :-------------: | :-------------: | :-------------: | :-------------: |
-| **OkHttp client**  | `com.paypal.mocca:mocca-okhttp:0.0.3` | `com.paypal.mocca.client.MoccaOkHttpClient` | |
-| **Apache HTTP client 5**  | `com.paypal.mocca:mocca-hc5:0.0.3` | `com.paypal.mocca.client.MoccaApache5Client` | Apache HTTP client 5 |
-| **Apache HTTP client**  | `com.paypal.mocca:mocca-apache:0.0.3` | `com.paypal.mocca.client.MoccaApacheClient` | Original Apache HTTP client |
-| **Google HTTP client**  | `com.paypal.mocca:mocca-google:0.0.3` | `com.paypal.mocca.client.MoccaGoogleHttpClient` | |
-| **Java HTTP2 client**  | `com.paypal.mocca:mocca-http2:0.0.3` | `com.paypal.mocca.client.MoccaHttp2Client` | HTTP2 client provided by the JDK |
-| **JAX-RS 2 client**  | `com.paypal.mocca:mocca-jaxrs2:0.0.3` | `com.paypal.mocca.client.MoccaJaxrsClient` | |
+| **OkHttp client**  | `com.paypal.mocca:mocca-okhttp:0.0.4` | `com.paypal.mocca.client.MoccaOkHttpClient` | |
+| **Apache HTTP client 5**  | `com.paypal.mocca:mocca-hc5:0.0.4` | `com.paypal.mocca.client.MoccaApache5Client` | Apache HTTP client 5 |
+| **Apache HTTP client**  | `com.paypal.mocca:mocca-apache:0.0.4` | `com.paypal.mocca.client.MoccaApacheClient` | Original Apache HTTP client |
+| **Google HTTP client**  | `com.paypal.mocca:mocca-google:0.0.4` | `com.paypal.mocca.client.MoccaGoogleHttpClient` | |
+| **Java HTTP2 client**  | `com.paypal.mocca:mocca-http2:0.0.4` | `com.paypal.mocca.client.MoccaHttp2Client` | HTTP2 client provided by the JDK |
+| **JAX-RS 2 client**  | `com.paypal.mocca:mocca-jaxrs2:0.0.4` | `com.paypal.mocca.client.MoccaJaxrsClient` | |
 
 The table above includes only synchronous clients, and the code samples in this section are specific to synchronous clients. For information about supported asynchronous clients, and how to configure it, please read section **Asynchronous development**.
 
@@ -599,7 +599,7 @@ A few important notes:
 
 ### 6.4 Gathering metrics
 
-Mocca supports [Micrometer](https://micrometer.io/)-based metrics via the optional library `com.paypal.mocca:mocca-micrometer:0.0.3`. These metrics primarily revolve around HTTP interactions with the target GraphQL server. The metrics have identifiers that start with `mocca.`.
+Mocca supports [Micrometer](https://micrometer.io/)-based metrics via the optional library `com.paypal.mocca:mocca-micrometer:0.0.4`. These metrics primarily revolve around HTTP interactions with the target GraphQL server. The metrics have identifiers that start with `mocca.`.
 
 The example below shows how to enable metric gathering in Mocca using Micrometer:
 
@@ -619,7 +619,7 @@ BooksAppClient micrometerEnabledClient = MoccaClient.Builder
 
 ### 6.5 Configuring resilience
 
-Mocca supports [Resilience4j](https://github.com/resilience4j/resilience4j)-based resilience features via the optional library `com.paypal.mocca:mocca-resilience4j:0.0.3`.
+Mocca supports [Resilience4j](https://github.com/resilience4j/resilience4j)-based resilience features via the optional library `com.paypal.mocca:mocca-resilience4j:0.0.4`.
 
 The example below shows how to configure resilience features in a Mocca client using Resilience4j:
 
@@ -723,7 +723,7 @@ The table below shows all async HTTP clients supported by Mocca, followed by an 
 
 | HTTP client  | Dependency | Client class |
 | :-------------: | :-------------: | :-------------: |
-| **Apache HTTP client 5**  | `com.paypal.mocca:mocca-hc5:0.0.3` | `com.paypal.mocca.client.MoccaAsyncApache5Client` |
+| **Apache HTTP client 5**  | `com.paypal.mocca:mocca-hc5:0.0.4` | `com.paypal.mocca.client.MoccaAsyncApache5Client` |
 
 ``` java
 MoccaAsyncApache5Client asyncHttpClient = new MoccaAsyncApache5Client();

--- a/docs/END_USER_DOCUMENT.md
+++ b/docs/END_USER_DOCUMENT.md
@@ -401,7 +401,7 @@ Mocca `SelectionSet` supports two options:
 
 - If annotation is present and its `value` attribute is set, Mocca automatic selection set resolution is turned OFF, and `SelectionSet` `value` is used to define the selection set. In this case if `ignore` value is also set, then that is not used by Mocca, and a warning is logged.
 - If annotation is present, its value attribute is NOT set, but `ignore` is, then Mocca automatic selection set resolution is turned ON, and `SelectionSet` `ignore` is used to pick which response DTO fields to ignore from the selection set.
-- If annotation is present and both `value` and `ignore` attributes are NOT set, then a `MoccaException` is thrown.
+- If annotation is present and both `value` and `ignore` attributes are NOT set, then a `MoccaException` is thrown (notice it will be wrapped in a `feign.codec.EncodeException`).
 
 It is important to mention though that, when `SelectionSet` annotation is present, although Mocca won't resolve automatically the selection set using the return type, still application has to make sure all fields in the provided custom selection set exist in the DTO used in the return type.
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,6 +1,17 @@
 
 # Release notes
 
+## 0.0.4
+
+#### Release date
+TBD
+
+#### New features and enhancements
+TBD
+
+#### Bug fixes
+TBD
+
 ## 0.0.3
 
 #### Release date

--- a/mocca-client/build.gradle
+++ b/mocca-client/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
     implementation lib.slf4j_api,
-                   lib.feign_core,
                    lib.jackson_databind,
                    lib.jackson_datatype_jsr301,
                    lib.jackson_modules_java8
 
-    api lib.jakarta_validation_api
+    api lib.feign_core,
+        lib.jakarta_validation_api
 
     testImplementation lib.testng,
                        lib.slf4j_simple,


### PR DESCRIPTION
Although originally it was attempted to avoid this, EncodeException and DecodeException need to be available for applications, as they wrap every exception thrown by Mocca.