### PR TITLE
Exposing Feign to applications during compilation time

### DIFF
--- a/docs/END_USER_DOCUMENT.md
+++ b/docs/END_USER_DOCUMENT.md
@@ -401,7 +401,7 @@ Mocca `SelectionSet` supports two options:
 
 - If annotation is present and its `value` attribute is set, Mocca automatic selection set resolution is turned OFF, and `SelectionSet` `value` is used to define the selection set. In this case if `ignore` value is also set, then that is not used by Mocca, and a warning is logged.
 - If annotation is present, its value attribute is NOT set, but `ignore` is, then Mocca automatic selection set resolution is turned ON, and `SelectionSet` `ignore` is used to pick which response DTO fields to ignore from the selection set.
-- If annotation is present and both `value` and `ignore` attributes are NOT set, then a `MoccaException` is thrown.
+- If annotation is present and both `value` and `ignore` attributes are NOT set, then a `MoccaException` is thrown (notice it will be wrapped in a `feign.codec.EncodeException`).
 
 It is important to mention though that, when `SelectionSet` annotation is present, although Mocca won't resolve automatically the selection set using the return type, still application has to make sure all fields in the provided custom selection set exist in the DTO used in the return type.
 

--- a/mocca-client/build.gradle
+++ b/mocca-client/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
     implementation lib.slf4j_api,
-                   lib.feign_core,
                    lib.jackson_databind,
                    lib.jackson_datatype_jsr301,
                    lib.jackson_modules_java8
 
-    api lib.jakarta_validation_api
+    api lib.feign_core,
+        lib.jakarta_validation_api
 
     testImplementation lib.testng,
                        lib.slf4j_simple,


### PR DESCRIPTION
Although originally it was attempted to avoid this, EncodeException and DecodeException need to be available for applications, as they wrap every exception thrown by Mocca.